### PR TITLE
Feature/fixing validation report

### DIFF
--- a/DashboardFrontend/DetachedWindows/ValidationReportDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/ValidationReportDetached.xaml
@@ -26,285 +26,287 @@
 
     <Border BorderThickness="10"
             Background="{DynamicResource BackgroundColor}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="4.5*" MinWidth="280"/>
+                <ColumnDefinition Width="10"/>
+                <ColumnDefinition Width="2*" MinWidth="100"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="30"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-        <Grid Name="gridValidationReport"
-                      Margin="0,0,20,0"
-                      Grid.Column="0"
-                      Grid.Row="1">
-
-            <!-- Body -->
-            <Grid Grid.Row="1">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="4.5*" MinWidth="280"/>
-                    <ColumnDefinition Width="10"/>
-                    <ColumnDefinition Width="2*" MinWidth="100"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="30"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-
-                <!-- Validations TreeView Header -->
-                <Grid>
-                    <TextBlock Text="Validations"
-                                   Margin="5"
-                                   Foreground="LightGray"
-                                   FontWeight="Bold"/>
-                    <StackPanel Grid.Column="1"
-                                    Orientation="Horizontal" 
-                                    HorizontalAlignment="Right">
-                        <ToggleButton Style="{DynamicResource DefaultToggleButton}"
-                                          IsChecked="{Binding ShowOk,UpdateSourceTrigger=PropertyChanged}"
-                                          Margin="0,2,0,2">
-                            <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                                <Image Source="/Icons/Validation.png"
-                                           Margin="0 0 2 0"
-                                           MaxHeight="20"/>
-                                <TextBlock Text="{Binding SelectedExecution.OkTotalCount,FallbackValue='N/A'}"
-                                               VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ToggleButton>
-                        <ToggleButton Style="{DynamicResource DefaultToggleButton}"
-                                          IsChecked="{Binding ShowDisabled,UpdateSourceTrigger=PropertyChanged}"
-                                          Margin="0, 2, 0, 2">
-                            <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                                <Image Source="/Icons/Warning.png"
-                                           Margin="0 0 2 0"
-                                           MaxHeight="20"/>
-                                <TextBlock Text="{Binding SelectedExecution.DisabledTotalCount,FallbackValue='N/A'}"
-                                               VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ToggleButton>
-                        <ToggleButton Style="{DynamicResource DefaultToggleButton}"
-                                          IsChecked="{Binding ShowFailed,UpdateSourceTrigger=PropertyChanged}"
-                                          Margin="0,2,0,2">
-                            <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                                <Image Source="/Icons/Fatal.png"
-                                           Margin="0 0 2 0"
-                                           MaxHeight="20"/>
-                                <TextBlock Text="{Binding SelectedExecution.FailedTotalCount,FallbackValue='N/A'}"
-                                               VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ToggleButton>
+            <!-- Validations TreeView Header -->
+            <Grid>
+                <TextBlock Text="Validations"
+                           Margin="5"
+                           Foreground="{DynamicResource HeaderForegroundColor}"
+                           FontWeight="Bold"/>
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal" 
+                            HorizontalAlignment="Right">
+                    <ToggleButton Style="{DynamicResource DefaultToggleButton}"
+                                  IsChecked="{Binding ShowEmpty,UpdateSourceTrigger=PropertyChanged}"
+                                  Margin="0,2,0,2">
                         <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                            <TextBlock Text="{Binding SelectedExecution.TotalCount,FallbackValue='N/A',StringFormat='(of {0})'}"
-                                           VerticalAlignment="Center"
-                                           Foreground="Gray"/>
+                            <TextBlock Text="Show empty"
+                                       VerticalAlignment="Center"/>
                         </StackPanel>
+                    </ToggleButton>
+                    <ToggleButton Style="{DynamicResource DefaultToggleButton}"
+                                  IsChecked="{Binding ShowOk,UpdateSourceTrigger=PropertyChanged}"
+                                  Margin="0,2,0,2">
+                        <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
+                            <Image Source="/Icons/Validation.png"
+                                   Margin="0 0 2 0"
+                                   MaxHeight="20"/>
+                            <TextBlock Text="{Binding SelectedExecution.OkTotalCount,FallbackValue='N/A'}"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ToggleButton>
+                    <ToggleButton Style="{DynamicResource DefaultToggleButton}"
+                                  IsChecked="{Binding ShowDisabled,UpdateSourceTrigger=PropertyChanged}"
+                                  Margin="0, 2, 0, 2">
+                        <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
+                            <Image Source="/Icons/Warning.png"
+                                   Margin="0 0 2 0"
+                                   MaxHeight="20"/>
+                            <TextBlock Text="{Binding SelectedExecution.DisabledTotalCount,FallbackValue='N/A'}"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ToggleButton>
+                    <ToggleButton Style="{DynamicResource DefaultToggleButton}"
+                                  IsChecked="{Binding ShowFailed,UpdateSourceTrigger=PropertyChanged}"
+                                  Margin="0,2,0,2">
+                        <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
+                            <Image Source="/Icons/Fatal.png"
+                                   Margin="0 0 2 0"
+                                   MaxHeight="20"/>
+                            <TextBlock Text="{Binding SelectedExecution.FailedTotalCount,FallbackValue='N/A'}"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ToggleButton>
+                    <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
+                        <TextBlock Text="{Binding SelectedExecution.TotalCount,FallbackValue='N/A',StringFormat='(of {0})'}"
+                                   VerticalAlignment="Center"
+                                   Foreground="Gray"/>
                     </StackPanel>
-                </Grid>
-                <!-- Validations TreeView -->
-                <Border Grid.Row="1" BorderBrush="{DynamicResource BorderColor}" BorderThickness="1">
-                    <Grid Background="{DynamicResource CanvasColor}">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="3*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="30"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-
-                        <ComboBox Margin="2" 
-                                          Style="{DynamicResource ComboBoxExecutions}" 
-                                          ItemsSource="{Binding Executions}" 
-                                          SelectedItem="{Binding SelectedExecution, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}" 
-                                                           VerticalAlignment="Center"
-                                                           Foreground="White"/>
-                                        <TextBlock Text="{Binding StartTime, StringFormat=' ({0:dd/MM HH:mm})'}" 
-                                                           VerticalAlignment="Center"
-                                                           Foreground="LightGray"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-
-                        <TextBox x:Name="TextBoxValidationsSearchBar"
-                                         Grid.Column="1"
-                                         Margin="2"
-                                         Style="{DynamicResource ValidationsSearchBox}"
-                                         Text="{Binding NameFilter, UpdateSourceTrigger=PropertyChanged}"
-                                         Foreground="White"
-                                         CaretBrush="White"/>
-
-                        <Image Source="/Icons/Magnifyingglass.png"
-                                       Grid.Column="1"
-                                       HorizontalAlignment="Right"
-                                       Margin="0 0 5 0"
-                                       Width="20"/>
-
-                        <TreeView Grid.Row="1"
-                                          Grid.ColumnSpan="2"
-                                          Name="TreeViewValidations"
-                                          Background="Transparent"
-                                          BorderBrush="Transparent"
-                                          ItemsSource="{Binding ManagerView}"
-                                          VirtualizingPanel.IsVirtualizing="True"
-                                          VirtualizingPanel.VirtualizationMode="Recycling"
-                                          VirtualizingPanel.ScrollUnit="Pixel"
-                                          TreeViewItem.Expanded="TreeViewValidations_Expanded"
-                                          TreeViewItem.Collapsed="TreeViewValidations_Collapsed">
-                            <TreeView.ItemTemplate>
-                                <HierarchicalDataTemplate ItemsSource="{Binding ValidationView}">
-                                    <StackPanel Orientation="Horizontal" 
-                                                        Height="20">
-                                        <Image Source="{Binding Converter={StaticResource CountToImageConverter}}"
-                                                       Margin="0 0 4 0"/>
-                                        <TextBlock Text="{Binding Name}" 
-                                                           VerticalAlignment="Center"/>
-                                        <TextBlock Text="{Binding ContextId, StringFormat=' (ID {0})'}"
-                                                           VerticalAlignment="Center"
-                                                           Foreground="LightGray"/>
-                                    </StackPanel>
-                                    <HierarchicalDataTemplate.ItemTemplate>
-                                        <DataTemplate>
-                                            <StackPanel Orientation="Horizontal" 
-                                                                Height="20" 
-                                                                Margin="0 5 0 0">
-                                                <Image Source="{Binding Converter={StaticResource StatusToImageConverter}}"
-                                                               Margin="10 0 5 0"/>
-                                                <TextBlock Text="{Binding Name}" 
-                                                                   VerticalAlignment="Center"/>
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </HierarchicalDataTemplate.ItemTemplate>
-                                </HierarchicalDataTemplate>
-                            </TreeView.ItemTemplate>
-                            <TreeView.Resources>
-                                <Style TargetType="TreeViewItem">
-                                    <Setter Property="Foreground" Value="White"/>
-                                    <Setter Property="MinHeight" Value="25"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Converter={StaticResource IsValidationTestConverter}}" Value="False">
-                                            <Setter Property="Focusable" Value="False"/>
-                                            <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TreeView.Resources>
-                        </TreeView>
-                    </Grid>
-                </Border>
-
-                <Grid Grid.Column="2">
-                    <TextBlock Text="Summary"
-                                       Margin="0 5 5 5"
-                                       Foreground="LightGray"
-                                       FontWeight="Bold"/>
-                </Grid>
-                <Border BorderBrush="{DynamicResource BorderColor}"
-                                BorderThickness="1"
-                                Grid.Row="1"
-                                Grid.Column="2">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel Orientation="Vertical" 
-                                        Background="{DynamicResource CanvasColor}"
-                                        DataContext="{Binding ElementName=TreeViewValidations, Path=SelectedItem}">
-                            <TextBlock Text="Description" 
-                                           FontWeight="Bold" 
-                                           Margin="10 10 10 0"
-                                           Foreground="LightGray"/>
-                            <TextBlock Text="{Binding Name, FallbackValue='No active selection'}"
-                                           Margin="10 0 10 0"/>
-
-                            <TextBlock Text="Toolkit ID"
-                                               FontWeight="Bold"
-                                               Margin="10 20 10 0"
-                                               Foreground="LightGray"/>
-                            <TextBlock Text="{Binding ToolkitId, TargetNullValue='N/A'}"
-                                               Margin="10 0 10 0"/>
-
-                            <TextBlock Text="Result" 
-                                           FontWeight="Bold" 
-                                           Foreground="LightGray"
-                                           Margin="10 20 10 0"/>
-                            <StackPanel Orientation="Horizontal"
-                                            Margin="10 0 10 0">
-                                <Image Width="20">
-                                    <Image.Style>
-                                        <Style TargetType="{x:Type Image}">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Converter={StaticResource IsValidationTestConverter}}" Value="True">
-                                                    <Setter Property="Source" Value="{Binding Converter={StaticResource StatusToImageConverter}}"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Image.Style>
-                                </Image>
-                                <TextBlock Text="{Binding Status}"
-                                               Margin="5 0 0 0"
-                                               VerticalAlignment="Center"/>
-                            </StackPanel>
-
-                            <TextBlock Text="Row count" 
-                                           FontWeight="Bold" 
-                                           Margin="10 20 10 0"
-                                           Foreground="LightGray"/>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="Source "
-                                               Foreground="LightGray"
-                                               Margin="10 0 5 0"/>
-                                <TextBlock Text="{Binding SrcCount, TargetNullValue='N/A'}"
-                                               Margin="0 0 10 0"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="Destination "
-                                               Foreground="LightGray"
-                                               Margin="10 0 5 0"/>
-                                <TextBlock Text="{Binding DstCount, TargetNullValue='N/A'}"
-                                               Margin="0 0 10 0"/>
-                            </StackPanel>
-
-                            <TextBlock Text="Copy SQL"
-                                           FontWeight="Bold"
-                                           Foreground="LightGray"
-                                           Margin="10 20 10 0"/>
-                            <StackPanel Orientation="Horizontal"
-                                            Margin="10 5 10 0"
-                                            Height="30">
-                                <Button Margin="0 0 5 0"
-                                            Click="CopySrcSql_Click"
-                                            MouseLeave="ButtonCopySql_MouseLeave"
-                                            IsEnabled="{Binding SrcSql, Converter={StaticResource SqlToBoolConverter}, FallbackValue=False}"
-                                            Content="Source"/>
-                                <Button Click="CopyDestSql_Click"
-                                                MouseLeave="ButtonCopySql_MouseLeave"
-                                                IsEnabled="{Binding DstSql, Converter={StaticResource SqlToBoolConverter}, FallbackValue=False}"
-                                                Content="Destination"/>
-
-                                <Popup x:Name="PopupCopySql"
-                                               Placement="Mouse">
-                                    <Border BorderBrush="{DynamicResource BorderColor}"
-                                                    BorderThickness="1">
-                                        <Label x:Name="TextBlockPopupSql"
-                                                       Style="{DynamicResource PopupLabel}"/>
-                                    </Border>
-                                </Popup>
-                            </StackPanel>
-                            <StackPanel.Resources>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="Foreground" Value="White"/>
-                                    <Setter Property="FontSize" Value="14"/>
-                                    <Setter Property="TextWrapping" Value="Wrap"/>
-                                </Style>
-                                <Style TargetType="Button">
-                                    <Setter Property="FontFamily" Value="Segoe UI"/>
-                                    <Setter Property="FontSize" Value="14"/>
-                                    <Style.Triggers>
-                                        <Trigger Property="IsEnabled" Value="False">
-                                            <Setter Property="Foreground" Value="Gray"/>
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </StackPanel.Resources>
-                        </StackPanel>
-                    </ScrollViewer>
-                </Border>
+                </StackPanel>
             </Grid>
+            <!-- Validations TreeView -->
+            <Border Grid.Row="1" BorderBrush="{DynamicResource BorderColor}" BorderThickness="1">
+                <Grid Background="{DynamicResource CanvasColor}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="3*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="30"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <ComboBox Margin="2" 
+                              ToolTip="Choose which execution to view data from"
+                              Style="{DynamicResource ComboBoxExecutions}" 
+                              ItemsSource="{Binding Executions}" 
+                              SelectedItem="{Binding SelectedExecution, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}" 
+                                               VerticalAlignment="Center"
+                                               Foreground="{DynamicResource HeaderForegroundColor}"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+
+                    <TextBox x:Name="TextBoxValidationsSearchBar"
+                             Grid.Column="1"
+                             Margin="2"
+                             Style="{DynamicResource ValidationsSearchBox}"
+                             Text="{Binding NameFilter, UpdateSourceTrigger=PropertyChanged}"
+                             ToolTip="Search for managers by their name or context ID"
+                             Foreground="{DynamicResource ForegroundColor}"
+                             CaretBrush="{DynamicResource ForegroundColor}"/>
+
+                    <Image Source="/Icons/Magnifyingglass.png"
+                           Grid.Column="1"
+                           HorizontalAlignment="Right"
+                           Margin="0 0 5 0"
+                           Width="20"/>
+
+                    <TreeView Grid.Row="1"
+                              Grid.ColumnSpan="2"
+                              Name="TreeViewValidations"
+                              Background="Transparent"
+                              BorderBrush="Transparent"
+                              ItemsSource="{Binding ManagerView}"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling"
+                              VirtualizingPanel.ScrollUnit="Pixel"
+                              TreeViewItem.Expanded="TreeViewValidations_Expanded"
+                              TreeViewItem.Collapsed="TreeViewValidations_Collapsed">
+                        <TreeView.ItemTemplate>
+                            <HierarchicalDataTemplate ItemsSource="{Binding ValidationView}">
+                                <StackPanel Orientation="Horizontal" 
+                                            Height="20">
+                                    <Image Source="{Binding Converter={StaticResource CountToImageConverter}}"
+                                           Margin="0 0 4 0"/>
+                                    <TextBlock Text="{Binding Name}" 
+                                               VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding ContextId, StringFormat=' (ID {0})'}"
+                                               VerticalAlignment="Center"
+                                               Foreground="{DynamicResource HeaderForegroundColor}"/>
+                                </StackPanel>
+                                <HierarchicalDataTemplate.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" 
+                                                    Height="20" 
+                                                    Margin="0 5 0 0">
+                                            <Image Source="{Binding Converter={StaticResource StatusToImageConverter}}"
+                                                   Margin="10 0 5 0"/>
+                                            <TextBlock Text="{Binding Name}" 
+                                                       VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </HierarchicalDataTemplate.ItemTemplate>
+                            </HierarchicalDataTemplate>
+                        </TreeView.ItemTemplate>
+                        <TreeView.Resources>
+                            <Style TargetType="TreeViewItem">
+                                <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
+                                <Setter Property="MinHeight" Value="25"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Converter={StaticResource IsValidationTestConverter}}" Value="False">
+                                        <Setter Property="Focusable" Value="False"/>
+                                        <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TreeView.Resources>
+                    </TreeView>
+                </Grid>
+            </Border>
+
+            <Grid Grid.Column="2">
+                <TextBlock Text="Details"
+                           Margin="0 5 5 5"
+                           Foreground="{DynamicResource HeaderForegroundColor}"
+                           FontWeight="Bold"/>
+            </Grid>
+            <Border BorderBrush="{DynamicResource BorderColor}"
+                    BorderThickness="1"
+                    Grid.Row="1"
+                    Grid.Column="2">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Orientation="Vertical" 
+                                Background="{DynamicResource CanvasColor}"
+                                DataContext="{Binding ElementName=TreeViewValidations, Path=SelectedItem}">
+                        <TextBlock Text="Description" 
+                                   FontWeight="Bold" 
+                                   Margin="10 10 10 0"
+                                   Foreground="{DynamicResource HeaderForegroundColor}"/>
+                        <TextBlock Text="{Binding Name, FallbackValue='No active selection'}"
+                                   Margin="10 0 10 0"/>
+
+                        <TextBlock Text="Toolkit ID"
+                                   FontWeight="Bold"
+                                   Margin="10 20 10 0"
+                                   Foreground="{DynamicResource HeaderForegroundColor}"/>
+                        <TextBlock Text="{Binding ToolkitId, TargetNullValue='N/A'}"
+                                   Margin="10 0 10 0"/>
+
+                        <TextBlock Text="Result" 
+                                   FontWeight="Bold" 
+                                   Foreground="{DynamicResource HeaderForegroundColor}"
+                                   Margin="10 20 10 0"/>
+                        <StackPanel Orientation="Horizontal"
+                                    Margin="10 0 10 0">
+                            <Image Width="20">
+                                <Image.Style>
+                                    <Style TargetType="{x:Type Image}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Converter={StaticResource IsValidationTestConverter}}" Value="True">
+                                                <Setter Property="Source" Value="{Binding Converter={StaticResource StatusToImageConverter}}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Image.Style>
+                            </Image>
+                            <TextBlock Text="{Binding Status}"
+                                       Margin="5 0 0 0"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+
+                        <TextBlock Text="Row count" 
+                                   FontWeight="Bold" 
+                                   Margin="10 20 10 0"
+                                   Foreground="{DynamicResource HeaderForegroundColor}"/>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Source "
+                                       Foreground="{DynamicResource HeaderForegroundColor}"
+                                       Margin="10 0 5 0"/>
+                            <TextBlock Text="{Binding SrcCount, TargetNullValue='N/A'}"
+                                       Margin="0 0 10 0"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Destination "
+                                       Foreground="{DynamicResource HeaderForegroundColor}"
+                                       Margin="10 0 5 0"/>
+                            <TextBlock Text="{Binding DstCount, TargetNullValue='N/A'}"
+                                       Margin="0 0 10 0"/>
+                        </StackPanel>
+
+                        <TextBlock Text="Copy SQL"
+                                   FontWeight="Bold"
+                                   Foreground="{DynamicResource HeaderForegroundColor}"
+                                   Margin="10 20 10 10"/>
+                        <StackPanel Orientation="Horizontal"
+                                    Margin="10 5 10 10"
+                                    Height="30">
+                            <Button Margin="0 0 20 0"
+                                    Click="CopySrcSql_Click"
+                                    MouseLeave="ButtonCopySql_MouseLeave"
+                                    IsEnabled="{Binding SrcSql, Converter={StaticResource SqlToBoolConverter}, FallbackValue=False}"
+                                    Template="{DynamicResource CopySqlButton}"
+                                    Content="Source"/>
+                            <Button Click="CopyDestSql_Click"
+                                    MouseLeave="ButtonCopySql_MouseLeave"
+                                    IsEnabled="{Binding DstSql, Converter={StaticResource SqlToBoolConverter}, FallbackValue=False}"
+                                    Template="{DynamicResource CopySqlButton}"
+                                    Content="Destination"/>
+
+                            <Popup x:Name="PopupCopySql"
+                                   Placement="Mouse">
+                                <Border BorderBrush="{DynamicResource BorderColor}"
+                                        BorderThickness="1">
+                                    <Label x:Name="TextBlockPopupSql"
+                                           Style="{DynamicResource PopupLabel}"/>
+                                </Border>
+                            </Popup>
+                        </StackPanel>
+                        <StackPanel.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
+                                <Setter Property="FontSize" Value="14"/>
+                                <Setter Property="TextWrapping" Value="Wrap"/>
+                            </Style>
+                            <Style TargetType="Button">
+                                <Setter Property="FontFamily" Value="Segoe UI"/>
+                                <Setter Property="FontSize" Value="14"/>
+                                <Setter Property="Width" Value="80"/>
+                                <Style.Triggers>
+                                    <Trigger Property="IsEnabled" Value="False">
+                                        <Setter Property="Foreground" Value="Gray"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Resources>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
         </Grid>
     </Border>
 </Window>

--- a/DashboardFrontend/DetachedWindows/ValidationReportDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/ValidationReportDetached.xaml
@@ -49,10 +49,9 @@
                     <ToggleButton Style="{DynamicResource DefaultToggleButton}"
                                   IsChecked="{Binding ShowEmpty,UpdateSourceTrigger=PropertyChanged}"
                                   Margin="0,2,0,2">
-                        <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                            <TextBlock Text="Show empty"
-                                       VerticalAlignment="Center"/>
-                        </StackPanel>
+                        <TextBlock Text="Show empty"
+                                   Padding="6"
+                                   VerticalAlignment="Center"/>
                     </ToggleButton>
                     <ToggleButton Style="{DynamicResource DefaultToggleButton}"
                                   IsChecked="{Binding ShowOk,UpdateSourceTrigger=PropertyChanged}"
@@ -87,11 +86,10 @@
                                        VerticalAlignment="Center"/>
                         </StackPanel>
                     </ToggleButton>
-                    <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                        <TextBlock Text="{Binding SelectedExecution.TotalCount,FallbackValue='N/A',StringFormat='(of {0})'}"
-                                   VerticalAlignment="Center"
-                                   Foreground="Gray"/>
-                    </StackPanel>
+                    <TextBlock Text="{Binding SelectedExecution.TotalCount,FallbackValue='N/A',StringFormat='(of {0})'}"
+                               VerticalAlignment="Center"
+                               Padding="6"
+                               Foreground="Gray"/>
                 </StackPanel>
             </Grid>
             <!-- Validations TreeView -->
@@ -113,11 +111,9 @@
                               SelectedItem="{Binding SelectedExecution, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}" 
-                                               VerticalAlignment="Center"
-                                               Foreground="{DynamicResource HeaderForegroundColor}"/>
-                                </StackPanel>
+                                <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}" 
+                                           VerticalAlignment="Center"
+                                           Foreground="{DynamicResource HeaderForegroundColor}"/>
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>

--- a/DashboardFrontend/DetachedWindows/ValidationReportDetached.xaml.cs
+++ b/DashboardFrontend/DetachedWindows/ValidationReportDetached.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using Model;
 using DashboardFrontend.ViewModels;
 using System.Windows.Controls.Primitives;
+using System.Diagnostics;
 
 namespace DashboardFrontend.DetachedWindows
 {
@@ -45,7 +46,7 @@ namespace DashboardFrontend.DetachedWindows
             item.IsSelected = false;
             if (tree.ItemContainerGenerator.ItemFromContainer(item) is ManagerObservable manager)
             {
-                if (!ViewModel.ExpandedManagerNames.Contains(manager.Name))
+                if (ViewModel.ExpandedManagerNames.Contains(manager.Name))
                 {
                     ViewModel.ExpandedManagerNames.Remove(manager.Name);
                 }

--- a/DashboardFrontend/MainWindow.xaml
+++ b/DashboardFrontend/MainWindow.xaml
@@ -493,10 +493,9 @@
                                 <ToggleButton Style="{DynamicResource DefaultToggleButton}"
                                               IsChecked="{Binding ShowEmpty,UpdateSourceTrigger=PropertyChanged}"
                                               Margin="0,2,0,2">
-                                    <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                                        <TextBlock Text="Show empty"
-                                                   VerticalAlignment="Center"/>
-                                    </StackPanel>
+                                    <TextBlock Text="Show empty"
+                                                Padding="6"
+                                                VerticalAlignment="Center"/>
                                 </ToggleButton>
                                 <ToggleButton Style="{DynamicResource DefaultToggleButton}"
                                               IsChecked="{Binding ShowOk,UpdateSourceTrigger=PropertyChanged}"
@@ -531,11 +530,10 @@
                                                    VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </ToggleButton>
-                                <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
-                                    <TextBlock Text="{Binding SelectedExecution.TotalCount,FallbackValue='N/A',StringFormat='(of {0})'}"
-                                               VerticalAlignment="Center"
-                                               Foreground="Gray"/>
-                                </StackPanel>
+                                <TextBlock Text="{Binding SelectedExecution.TotalCount,FallbackValue='N/A',StringFormat='(of {0})'}"
+                                            VerticalAlignment="Center"
+                                            Padding="6"
+                                            Foreground="Gray"/>
                             </StackPanel>
                         </Grid>
                         <!-- Validations TreeView -->
@@ -556,11 +554,9 @@
                                           SelectedItem="{Binding SelectedExecution, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}" 
-                                                           VerticalAlignment="Center"
-                                                           Foreground="{DynamicResource ForegroundColor}"/>
-                                            </StackPanel>
+                                            <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}" 
+                                                       VerticalAlignment="Center"
+                                                       Foreground="{DynamicResource ForegroundColor}"/>
                                         </DataTemplate>
                                     </ComboBox.ItemTemplate>
                                 </ComboBox>

--- a/DashboardFrontend/MainWindow.xaml
+++ b/DashboardFrontend/MainWindow.xaml
@@ -484,49 +484,57 @@
                         <!-- Validations TreeView Header -->
                         <Grid>
                             <TextBlock Text="Validations"
-                                   Margin="5"
-                                   Foreground="LightGray"
-                                   FontWeight="Bold"/>
+                                       Margin="5"
+                                       Foreground="{DynamicResource HeaderForegroundColor}"
+                                       FontWeight="Bold"/>
                             <StackPanel Grid.Column="1"
-                                    Orientation="Horizontal" 
-                                    HorizontalAlignment="Right">
+                                        Orientation="Horizontal" 
+                                        HorizontalAlignment="Right">
                                 <ToggleButton Style="{DynamicResource DefaultToggleButton}"
-                                          IsChecked="{Binding ShowOk,UpdateSourceTrigger=PropertyChanged}"
-                                          Margin="0,2,0,2">
+                                              IsChecked="{Binding ShowEmpty,UpdateSourceTrigger=PropertyChanged}"
+                                              Margin="0,2,0,2">
+                                    <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
+                                        <TextBlock Text="Show empty"
+                                                   VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </ToggleButton>
+                                <ToggleButton Style="{DynamicResource DefaultToggleButton}"
+                                              IsChecked="{Binding ShowOk,UpdateSourceTrigger=PropertyChanged}"
+                                              Margin="0,2,0,2">
                                     <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
                                         <Image Source="/Icons/Validation.png"
-                                           Margin="0 0 2 0"
-                                           MaxHeight="20"/>
+                                               Margin="0 0 2 0"
+                                               MaxHeight="20"/>
                                         <TextBlock Text="{Binding SelectedExecution.OkTotalCount,FallbackValue='N/A'}"
-                                               VerticalAlignment="Center"/>
+                                                   VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </ToggleButton>
                                 <ToggleButton Style="{DynamicResource DefaultToggleButton}"
-                                          IsChecked="{Binding ShowDisabled,UpdateSourceTrigger=PropertyChanged}"
-                                          Margin="0, 2, 0, 2">
+                                              IsChecked="{Binding ShowDisabled,UpdateSourceTrigger=PropertyChanged}"
+                                              Margin="0, 2, 0, 2">
                                     <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
                                         <Image Source="/Icons/Warning.png"
-                                           Margin="0 0 2 0"
-                                           MaxHeight="20"/>
+                                               Margin="0 0 2 0"
+                                               MaxHeight="20"/>
                                         <TextBlock Text="{Binding SelectedExecution.DisabledTotalCount,FallbackValue='N/A'}"
-                                               VerticalAlignment="Center"/>
+                                                   VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </ToggleButton>
                                 <ToggleButton Style="{DynamicResource DefaultToggleButton}"
-                                          IsChecked="{Binding ShowFailed,UpdateSourceTrigger=PropertyChanged}"
-                                          Margin="0,2,0,2">
+                                              IsChecked="{Binding ShowFailed,UpdateSourceTrigger=PropertyChanged}"
+                                              Margin="0,2,0,2">
                                     <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
                                         <Image Source="/Icons/Fatal.png"
-                                           Margin="0 0 2 0"
-                                           MaxHeight="20"/>
+                                               Margin="0 0 2 0"
+                                               MaxHeight="20"/>
                                         <TextBlock Text="{Binding SelectedExecution.FailedTotalCount,FallbackValue='N/A'}"
-                                               VerticalAlignment="Center"/>
+                                                   VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </ToggleButton>
                                 <StackPanel Orientation="Horizontal" Margin="6 0 6 0">
                                     <TextBlock Text="{Binding SelectedExecution.TotalCount,FallbackValue='N/A',StringFormat='(of {0})'}"
-                                           VerticalAlignment="Center"
-                                           Foreground="Gray"/>
+                                               VerticalAlignment="Center"
+                                               Foreground="Gray"/>
                                 </StackPanel>
                             </StackPanel>
                         </Grid>
@@ -551,10 +559,7 @@
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}" 
                                                            VerticalAlignment="Center"
-                                                           Foreground="White"/>
-                                                <TextBlock Text="{Binding StartTime, StringFormat=' ({0:dd/MM HH:mm})'}" 
-                                                           VerticalAlignment="Center"
-                                                           Foreground="LightGray"/>
+                                                           Foreground="{DynamicResource ForegroundColor}"/>
                                             </StackPanel>
                                         </DataTemplate>
                                     </ComboBox.ItemTemplate>
@@ -565,8 +570,9 @@
                                          Margin="2"
                                          Style="{DynamicResource ValidationsSearchBox}"
                                          Text="{Binding NameFilter, UpdateSourceTrigger=PropertyChanged}"
-                                         Foreground="White"
-                                         CaretBrush="White"/>
+                                         ToolTip="Search for managers by their name or context ID"
+                                         Foreground="{DynamicResource ForegroundColor}"
+                                         CaretBrush="{DynamicResource ForegroundColor}"/>
 
                                 <Image Source="/Icons/Magnifyingglass.png"
                                        Grid.Column="1"
@@ -595,7 +601,7 @@
                                                            VerticalAlignment="Center"/>
                                                 <TextBlock Text="{Binding ContextId, StringFormat=' (ID {0})'}"
                                                            VerticalAlignment="Center"
-                                                           Foreground="LightGray"/>
+                                                           Foreground="{DynamicResource HeaderForegroundColor}"/>
                                             </StackPanel>
                                             <HierarchicalDataTemplate.ItemTemplate>
                                                 <DataTemplate>
@@ -613,7 +619,7 @@
                                     </TreeView.ItemTemplate>
                                     <TreeView.Resources>
                                         <Style TargetType="TreeViewItem">
-                                            <Setter Property="Foreground" Value="White"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
                                             <Setter Property="MinHeight" Value="25"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding Converter={StaticResource IsValidationTestConverter}}" Value="False">
@@ -628,9 +634,9 @@
                         </Border>
 
                         <Grid Grid.Column="2">
-                            <TextBlock Text="Summary"
+                            <TextBlock Text="Details"
                                        Margin="0 5 5 5"
-                                       Foreground="LightGray"
+                                       Foreground="{DynamicResource HeaderForegroundColor}"
                                        FontWeight="Bold"/>
                             <Button Name="ButtonValidationReportDetach" 
                                     Click="DetachValidationReportButtonClick"
@@ -646,28 +652,28 @@
                                 Grid.Column="2">
                             <ScrollViewer VerticalScrollBarVisibility="Auto">
                                 <StackPanel Orientation="Vertical" 
-                                        Background="{DynamicResource CanvasColor}"
-                                        DataContext="{Binding ElementName=TreeViewValidations, Path=SelectedItem}">
+                                            Background="{DynamicResource CanvasColor}"
+                                            DataContext="{Binding ElementName=TreeViewValidations, Path=SelectedItem}">
                                     <TextBlock Text="Description" 
-                                           FontWeight="Bold" 
-                                           Margin="10 10 10 0"
-                                           Foreground="LightGray"/>
+                                               FontWeight="Bold" 
+                                               Margin="10 10 10 0"
+                                               Foreground="{DynamicResource HeaderForegroundColor}"/>
                                     <TextBlock Text="{Binding Name, FallbackValue='No active selection'}"
-                                           Margin="10 0 10 0"/>
+                                               Margin="10 0 10 0"/>
                                     
                                     <TextBlock Text="Toolkit ID"
                                                FontWeight="Bold"
                                                Margin="10 20 10 0"
-                                               Foreground="LightGray"/>
+                                               Foreground="{DynamicResource HeaderForegroundColor}"/>
                                     <TextBlock Text="{Binding ToolkitId, TargetNullValue='N/A'}"
                                                Margin="10 0 10 0"/>
 
                                     <TextBlock Text="Result" 
-                                           FontWeight="Bold" 
-                                           Foreground="LightGray"
-                                           Margin="10 20 10 0"/>
+                                               FontWeight="Bold" 
+                                               Foreground="{DynamicResource HeaderForegroundColor}"
+                                               Margin="10 20 10 0"/>
                                     <StackPanel Orientation="Horizontal"
-                                            Margin="10 0 10 0">
+                                                Margin="10 0 10 0">
                                         <Image Width="20">
                                             <Image.Style>
                                                 <Style TargetType="{x:Type Image}">
@@ -680,44 +686,46 @@
                                             </Image.Style>
                                         </Image>
                                         <TextBlock Text="{Binding Status}"
-                                               Margin="5 0 0 0"
-                                               VerticalAlignment="Center"/>
+                                                   Margin="5 0 0 0"
+                                                   VerticalAlignment="Center"/>
                                     </StackPanel>
                                         
                                     <TextBlock Text="Row count" 
-                                           FontWeight="Bold" 
-                                           Margin="10 20 10 0"
-                                           Foreground="LightGray"/>
+                                               FontWeight="Bold" 
+                                               Margin="10 20 10 0"
+                                               Foreground="{DynamicResource HeaderForegroundColor}"/>
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="Source "
-                                               Foreground="LightGray"
-                                               Margin="10 0 5 0"/>
+                                                   Foreground="{DynamicResource HeaderForegroundColor}"
+                                                   Margin="10 0 5 0"/>
                                         <TextBlock Text="{Binding SrcCount, TargetNullValue='N/A'}"
-                                               Margin="0 0 10 0"/>
+                                                   Margin="0 0 10 0"/>
                                     </StackPanel>
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="Destination "
-                                               Foreground="LightGray"
-                                               Margin="10 0 5 0"/>
+                                                   Foreground="{DynamicResource HeaderForegroundColor}"
+                                                   Margin="10 0 5 0"/>
                                         <TextBlock Text="{Binding DstCount, TargetNullValue='N/A'}"
-                                               Margin="0 0 10 0"/>
+                                                   Margin="0 0 10 0"/>
                                     </StackPanel>
 
                                     <TextBlock Text="Copy SQL"
-                                           FontWeight="Bold"
-                                           Foreground="LightGray"
-                                           Margin="10 20 10 0"/>
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource HeaderForegroundColor}"
+                                               Margin="10 20 10 10"/>
                                     <StackPanel Orientation="Horizontal"
-                                            Margin="10 5 10 0"
-                                            Height="30">
-                                        <Button Margin="0 0 5 0"
-                                            Click="CopySrcSql_Click"
-                                            MouseLeave="ButtonCopySql_MouseLeave"
-                                            IsEnabled="{Binding SrcSql, Converter={StaticResource SqlToBoolConverter}, FallbackValue=False}"
-                                            Content="Source"/>
+                                                Margin="10 5 10 10"
+                                                Height="30">
+                                        <Button Margin="0 0 20 0"
+                                                Click="CopySrcSql_Click"
+                                                MouseLeave="ButtonCopySql_MouseLeave"
+                                                IsEnabled="{Binding SrcSql, Converter={StaticResource SqlToBoolConverter}, FallbackValue=False}"
+                                                Template="{DynamicResource CopySqlButton}"
+                                                Content="Source"/>
                                         <Button Click="CopyDestSql_Click"
                                                 MouseLeave="ButtonCopySql_MouseLeave"
                                                 IsEnabled="{Binding DstSql, Converter={StaticResource SqlToBoolConverter}, FallbackValue=False}"
+                                                Template="{DynamicResource CopySqlButton}"
                                                 Content="Destination"/>
 
                                         <Popup x:Name="PopupCopySql"
@@ -731,13 +739,14 @@
                                     </StackPanel>
                                     <StackPanel.Resources>
                                         <Style TargetType="TextBlock">
-                                            <Setter Property="Foreground" Value="White"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
                                             <Setter Property="FontSize" Value="14"/>
                                             <Setter Property="TextWrapping" Value="Wrap"/>
                                         </Style>
                                         <Style TargetType="Button">
                                             <Setter Property="FontFamily" Value="Segoe UI"/>
                                             <Setter Property="FontSize" Value="14"/>
+                                            <Setter Property="Width" Value="80"/>
                                             <Style.Triggers>
                                                 <Trigger Property="IsEnabled" Value="False">
                                                     <Setter Property="Foreground" Value="Gray"/>

--- a/DashboardFrontend/MainWindow.xaml.cs
+++ b/DashboardFrontend/MainWindow.xaml.cs
@@ -1,14 +1,13 @@
-using DashboardFrontend.ViewModels;
+using DashboardFrontend.Charts;
 using DashboardFrontend.DetachedWindows;
+using DashboardFrontend.ViewModels;
+using LiveChartsCore.SkiaSharpView.WPF;
 using Model;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Threading.Tasks;
-using System.Windows.Media;
-using DashboardFrontend.Charts;
-using LiveChartsCore.SkiaSharpView.WPF;
 
 namespace DashboardFrontend
 {
@@ -16,9 +15,16 @@ namespace DashboardFrontend
     {
         public MainWindow()
         {
+            this.Dispatcher.UnhandledException += OnDispatcherUnhandledException;
             InitializeComponent();
             ViewModel = new(ListViewLog);
             DataContext = ViewModel;
+        }
+
+        private void OnDispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
+        {
+            MessageBox.Show($"An unexpected error occured: {e.Exception.Message}", "Error");
+            e.Handled = true;
         }
 
         public MainWindowViewModel ViewModel { get; }
@@ -237,7 +243,7 @@ namespace DashboardFrontend
             item.IsSelected = false;
             if (tree.ItemContainerGenerator.ItemFromContainer(item) is ManagerObservable manager)
             {
-                if (!ViewModel.ValidationReportViewModel.ExpandedManagerNames.Contains(manager.Name))
+                if (ViewModel.ValidationReportViewModel.ExpandedManagerNames.Contains(manager.Name))
                 {
                     ViewModel.ValidationReportViewModel.ExpandedManagerNames.Remove(manager.Name);
                 }

--- a/DashboardFrontend/StyleResources/DictionaryButtons.xaml
+++ b/DashboardFrontend/StyleResources/DictionaryButtons.xaml
@@ -144,7 +144,28 @@
         </Setter>
     </Style>
     
-    
+    <ControlTemplate x:Key="CopySqlButton" TargetType="Button">
+        <Border Background="{DynamicResource ButtonBackgroundColor}"
+                BorderBrush="{DynamicResource DarkBorderColor}"
+                BorderThickness="1"
+                CornerRadius="5"
+                Name="Border">
+            <ContentPresenter Name="Presenter"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              TextBlock.Foreground="{DynamicResource ForegroundColor}"/>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Border" Property="Control.Background" Value="{DynamicResource ButtonWindowOnHoverColor}"/>
+                <Setter TargetName="Border" Property="Control.BorderBrush" Value="{DynamicResource ForegroundColor}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="Presenter" Property="TextBlock.Foreground" Value="Gray"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
     <!-- Default design for buttons -->
     <Style x:Key="DefaultButton" TargetType="Button">
         <Setter Property="FontFamily" Value="Segoe UI"/>

--- a/DashboardFrontend/ViewModels/ManagerObservable.cs
+++ b/DashboardFrontend/ViewModels/ManagerObservable.cs
@@ -12,7 +12,8 @@ namespace DashboardFrontend.ViewModels
         {
             Name = mgr.Name;
             ContextId = mgr.ContextId;
-            Validations = mgr.Validations;
+            StartTime = mgr.StartTime;
+            Validations = new(mgr.Validations);
             ValidationView = (CollectionView)CollectionViewSource.GetDefaultView(Validations);
         }
             
@@ -29,6 +30,7 @@ namespace DashboardFrontend.ViewModels
         }
         public string Name { get; private set; }
         public int ContextId { get; private set; }
+        public System.DateTime? StartTime { get; private set; }
         public int FailedCount => Validations.Count(v => v.Status is ValidationStatus.Failed or ValidationStatus.FailMismatch);
         public int DisabledCount => Validations.Count(v => v.Status is ValidationStatus.Disabled);
         public int OkCount => Validations.Count(v => v.Status is ValidationStatus.Ok);

--- a/DashboardFrontend/ViewModels/ValidationReportViewModel.cs
+++ b/DashboardFrontend/ViewModels/ValidationReportViewModel.cs
@@ -39,11 +39,10 @@ namespace DashboardFrontend.ViewModels
             {
                 _selectedExecution = value;
                 OnPropertyChanged(nameof(SelectedExecution));
-                SetExecution(value);
+                RefreshViews();
             }
         }
         public List<string> ExpandedManagerNames = new();
-        public ObservableCollection<Manager> ManagerList { get; private set; } = new();
         private CollectionView _managerView;
         public CollectionView ManagerView
         {
@@ -72,7 +71,7 @@ namespace DashboardFrontend.ViewModels
             {
                 _nameFilter = value;
                 OnPropertyChanged(nameof(NameFilter));
-                ManagerView?.Refresh();
+                RefreshViews();
             }
         }
         private bool _showOk;
@@ -108,6 +107,17 @@ namespace DashboardFrontend.ViewModels
                 RefreshViews();
             }
         }
+        private bool _showEmpty = false;
+        public bool ShowEmpty
+        {
+            get => _showEmpty;
+            set
+            {
+                _showEmpty = value;
+                OnPropertyChanged(nameof(ShowEmpty));
+                RefreshViews();
+            }
+        }
         #endregion
 
         /// <summary>
@@ -127,10 +137,12 @@ namespace DashboardFrontend.ViewModels
         {
             if (exec is not null)
             {
+                ExpandedManagerNames.Clear();
                 ManagerView = (CollectionView)CollectionViewSource.GetDefaultView(exec.Managers);
                 ManagerView.Filter = OnManagersFilter;
                 ManagerView.SortDescriptions.Add(new(nameof(ManagerObservable.FailedCount), ListSortDirection.Descending));
                 ManagerView.SortDescriptions.Add(new(nameof(ManagerObservable.DisabledCount), ListSortDirection.Descending));
+                ManagerView.SortDescriptions.Add(new(nameof(ManagerObservable.StartTime), ListSortDirection.Ascending));
             }
         }
 
@@ -142,16 +154,14 @@ namespace DashboardFrontend.ViewModels
         private bool OnManagersFilter(object item)
         {
             ManagerObservable mgr = (ManagerObservable)item;
-            return mgr.Name.Contains(NameFilter);
+            return (mgr.Name.Contains(NameFilter) || mgr.ContextId.ToString() == NameFilter) && (!mgr.ValidationView.IsEmpty || ShowEmpty);
         }
 
         public bool OnValidationsFilter(object item)
         {
-            return item is ValidationTest val
-                ? (ShowOk && val.Status is ValidationStatus.Ok)
-                    || (ShowFailed && val.Status is ValidationStatus.Failed or ValidationStatus.FailMismatch)
-                    || (ShowDisabled && val.Status is ValidationStatus.Disabled)
-                : false;
+            return item is ValidationTest val && ((ShowOk && val.Status is ValidationStatus.Ok)
+                                              || (ShowFailed && val.Status is ValidationStatus.Failed or ValidationStatus.FailMismatch)
+                                              || (ShowDisabled && val.Status is ValidationStatus.Disabled));
         }
 
         /// <summary>
@@ -159,16 +169,14 @@ namespace DashboardFrontend.ViewModels
         /// </summary>
         private void RefreshViews()
         {
-            if (SelectedExecution != null && ManagerView != null)
+            if (SelectedExecution != null)
             {
-                foreach (object item in ManagerView)
+                foreach (var mgr in SelectedExecution.Managers)
                 {
-                    ManagerObservable mgr = (ManagerObservable)item;
-                    mgr.ValidationView?.Refresh();
+                    mgr.ValidationView.Refresh();
                     mgr.IsExpanded = ExpandedManagerNames.Contains(mgr.Name);
-                    
                 }
-                ManagerView.Refresh();
+                SetExecution(SelectedExecution);
             }
         }
     }


### PR DESCRIPTION
Added:
- Show Empty-button to hide managers with no shown validation tests
- Added a style for the Copy SQL-buttons
- Added tooltips where appropriate
- Added functionality to search for context ID

Bugfixes:
- Fixed bug where different validation report viewmodels were connected through the same "CollectionViewSource", and filtering affected all views
- Filtering is completely fixed and works as well as it did before adding the ability to view different executions
- Added a validation queue to ensure that if a validation test's manager is not yet registered in the system, it will be added at a later time when said manager exists

Others:
- Added a global exception-handling method in MainWindow.xaml.cs, which catches any unhandled exceptions that may occur (when not in debug-mode)

(Kasper: Læg mærke til hvor flot formatteret mit XAML er!)