### PR TITLE
Feature/bugfixes manager

### DIFF
--- a/DashboardBackend/DataUtilities.cs
+++ b/DashboardBackend/DataUtilities.cs
@@ -422,18 +422,24 @@ namespace DashboardBackend
                 distinctReports.Add(entries.Skip(i).Take(6).ToList());
             }
 
-            //Build system model network usage objects.
-            return (from item in distinctReports
-                    let executionId = item.First().ExecutionId.Value
-                    let logTime = item.First().LogTime.Value
-                    let bytesSend = (long)item.Find(e => e.ReportKey == "Interface 0: Bytes Send").ReportNumericValue
-                    let bytesSendDelta = (long)item.Find(e => e.ReportKey == "Interface 0: Bytes Send (Delta)").ReportNumericValue
-                    let bytesSendSpeed = (long)item.Find(e => e.ReportKey == "Interface 0: Bytes Send (Speed)").ReportNumericValue
-                    let bytesReceived = (long)item.Find(e => e.ReportKey == "Interface 0: Bytes Received").ReportNumericValue
-                    let bytesReceivedDelta = (long)item.Find(e => e.ReportKey == "Interface 0: Bytes Received (Delta)").ReportNumericValue
-                    let bytesReceivedSpeed = (long)item.Find(e => e.ReportKey == "Interface 0: Bytes Received (Speed)").ReportNumericValue
-                    select new NetworkUsage(executionId, bytesSend, bytesSendDelta, bytesSendSpeed, bytesReceived, bytesReceivedDelta, bytesReceivedSpeed, logTime))
-                    .ToList();
+            List<NetworkUsage> result = new();
+            foreach (var item in distinctReports)
+            {
+                int? execId = item.Find(i => i.ExecutionId.HasValue)?.ExecutionId.Value;
+                DateTime? logTime = item.Find(i => i.LogTime.HasValue)?.LogTime.Value;
+                long bytesSend = item.Find(e => e.ReportKey == "Interface 0: Bytes Send")?.ReportNumericValue ?? 0;
+                long bytesSendDelta = item.Find(e => e.ReportKey == "Interface 0: Bytes Send (Delta)")?.ReportNumericValue ?? 0;
+                long bytesSendSpeed = item.Find(e => e.ReportKey == "Interface 0: Bytes Send (Speed)")?.ReportNumericValue ?? 0;
+                long bytesReceived = item.Find(e => e.ReportKey == "Interface 0: Bytes Received")?.ReportNumericValue ?? 0;
+                long bytesReceivedDelta = item.Find(e => e.ReportKey == "Interface 0: Bytes Received (Delta)")?.ReportNumericValue ?? 0;
+                long bytesReceivedSpeed = item.Find(e => e.ReportKey == "Interface 0: Bytes Received (Speed)")?.ReportNumericValue ?? 0;
+
+                if (execId.HasValue && logTime.HasValue)
+                {
+                    result.Add(new NetworkUsage(execId.Value, bytesSend, bytesSendDelta, bytesSendSpeed, bytesReceived, bytesReceivedDelta, bytesReceivedSpeed, logTime.Value));
+                }
+            }
+            return result;
         }
     }
 }

--- a/DashboardFrontend/Charts/DataChart.cs
+++ b/DashboardFrontend/Charts/DataChart.cs
@@ -81,7 +81,7 @@ namespace DashboardFrontend.Charts
             ChartData.Values.Remove(data);
             string shortName = dataName.Split('.').Last();
             int managerIndex = ChartData.Series.FindIndex(e => e.Name == shortName);
-            ChartData.Series.RemoveAt(managerIndex);
+            if (managerIndex > -1) ChartData.Series.RemoveAt(managerIndex);
         }
 
         /// <summary>

--- a/DashboardFrontend/Charts/ManagerChart.cs
+++ b/DashboardFrontend/Charts/ManagerChart.cs
@@ -19,7 +19,7 @@ namespace DashboardFrontend.Charts
                 new Axis
                 {
                     Name = "Time",
-                    Labeler = value => DateTime.FromOADate(value).ToString("HH:mm:ss"),
+                    Labeler = value => DateTime.FromOADate(value).ToString("mm:ss"),
                     MinLimit = 0,
                     LabelsPaint = new SolidColorPaint(new SKColor(255, 255, 255)),
                     AnimationsSpeed = TimeSpan.FromMilliseconds(500),
@@ -34,10 +34,10 @@ namespace DashboardFrontend.Charts
                     Labeler = (value) => value.ToString("P"),
                     MaxLimit = 1,
                     MinLimit = 0,
-                    LabelsPaint = new SolidColorPaint(new SKColor(255, 255, 255)),
-                    SeparatorsPaint = new SolidColorPaint(new SKColor(255, 255, 255)),
                     MinStep = 0.25,
                     ForceStepToMin = true,
+                    LabelsPaint = new SolidColorPaint(new SKColor(255, 255, 255)),
+                    SeparatorsPaint = new SolidColorPaint(new SKColor(255, 255, 255)),
                     AnimationsSpeed = TimeSpan.FromMilliseconds(500),
                 }
             };

--- a/DashboardFrontend/Controller.cs
+++ b/DashboardFrontend/Controller.cs
@@ -81,7 +81,7 @@ namespace DashboardFrontend
             _vm.HealthReportViewModel = new HealthReportViewModel();
             HealthReportViewModels = new() { _vm.HealthReportViewModel };
 
-            _vm.ManagerViewModel = new ManagerViewModel(_vm.Window);
+            _vm.ManagerViewModel = new ManagerViewModel();
             ManagerViewModels = new() { _vm.ManagerViewModel };
         }
 

--- a/DashboardFrontend/Controller.cs
+++ b/DashboardFrontend/Controller.cs
@@ -81,7 +81,7 @@ namespace DashboardFrontend
             _vm.HealthReportViewModel = new HealthReportViewModel();
             HealthReportViewModels = new() { _vm.HealthReportViewModel };
 
-            _vm.ManagerViewModel = new ManagerViewModel();
+            _vm.ManagerViewModel = new ManagerViewModel(_vm.Window);
             ManagerViewModels = new() { _vm.ManagerViewModel };
         }
 

--- a/DashboardFrontend/Controller.cs
+++ b/DashboardFrontend/Controller.cs
@@ -126,7 +126,7 @@ namespace DashboardFrontend
             ManagerViewModel result = new();
             if (Conversion != null && Conversion.Executions.Any())
             {
-                result.UpdateData(Conversion.ActiveExecution.Managers);
+                result.UpdateData(Conversion.Executions);
             }
             ManagerViewModels.Add(result);
             return result;
@@ -560,7 +560,7 @@ namespace DashboardFrontend
                         vm.LastUpdated = DateTime.Now;
                         Application.Current.Dispatcher.Invoke(() =>
                         {
-                            vm.UpdateData(Conversion.ActiveExecution.Managers);
+                            vm.UpdateData(Conversion.Executions);
                         });
                     }
                 }

--- a/DashboardFrontend/DetachedWindows/ConnectDBDialog.xaml
+++ b/DashboardFrontend/DetachedWindows/ConnectDBDialog.xaml
@@ -8,8 +8,11 @@
         Height="200" 
         Width="350"
         Background="{DynamicResource BackgroundColor}"
+        BorderBrush="{DynamicResource BorderColor}"
+        BorderThickness="1"
         WindowStartupLocation="CenterScreen"
         WindowStyle="None"
+        FocusManager.FocusedElement="{Binding ElementName=TextBoxUserId}"
         ResizeMode="NoResize">
     <Border Margin="10">
         <Grid>

--- a/DashboardFrontend/DetachedWindows/HealthReportDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/HealthReportDetached.xaml
@@ -10,6 +10,11 @@
         Height="450"
         Width="800"
         DataContext="{Binding RelativeSource={RelativeSource Self}}">
+    <Window.Resources>
+        <Style TargetType="{x:Type lvc:CartesianChart}">
+            <Setter Property="Cursor" Value="Cross"/>
+        </Style>
+    </Window.Resources>
     <Border Background="{DynamicResource BackgroundColor}">
         <Grid Margin="10">
             <TabControl Background="{DynamicResource BackgroundColor}"

--- a/DashboardFrontend/DetachedWindows/LogDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/LogDetached.xaml
@@ -254,7 +254,6 @@
                             </ComboBox>
                             <TextBlock Foreground="{DynamicResource ForegroundColor}">Context ID filter</TextBlock>
                             <ItemsControl Style="{DynamicResource GridPopupItemsControlOverwrite}"
-                                          Height="{Binding ActualHeight, ElementName=ListViewLog, Converter={StaticResource FilterPopupHeightConverter}}" 
                                           ItemsSource="{Binding SelectedExecution.Managers}">
                                 <ItemsControl.Template>
                                     <ControlTemplate>

--- a/DashboardFrontend/DetachedWindows/LogDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/LogDetached.xaml
@@ -194,6 +194,7 @@
                             <Setter Property="FontSize" Value="14"/>
                             <Setter Property="Focusable" Value="False"/>
                             <Setter Property="ToolTip" Value="{Binding ManagerName, TargetNullValue='Context not found'}"/>
+                            <Setter Property="ToolTipService.InitialShowDelay" Value="200"/>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Type}" Value="Info">
                                     <Setter Property="Foreground" Value="{DynamicResource LogMessageInfoColor}"/>

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
@@ -11,15 +11,21 @@
         mc:Ignorable="d"
         Title="Manager statistics" 
         Height="720" 
-        Width="1280"
+        Width="1440"
         WindowStartupLocation="CenterScreen">
+    <Window.Resources>
+        <converters:CountToVisibilityConverter x:Key="CountToVisibilityConverter"/>
+        <Style TargetType="{x:Type lvc:CartesianChart}">
+            <Setter Property="Cursor" Value="Cross"/>
+        </Style>
+    </Window.Resources>
     <Border Background="{DynamicResource BackgroundColor}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="15"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="15"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="2*"/>
                 <ColumnDefinition Width="15"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
@@ -35,7 +41,7 @@
                           Height="100"
                           Width="5"
                           Background="{DynamicResource CanvasColor}"/>
-            
+
             <Grid x:Name="GridManagerList"
                   Grid.Row="1"
                   Grid.Column="1">
@@ -86,17 +92,17 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ID" 
                                             Binding="{Binding Manager.ContextId}"
-                                            Width="25pt"/>
-                        <DataGridTextColumn Header="Manager name" 
+                                            Width="0.5*"/>
+                        <DataGridTextColumn Header="Name" 
                                             Binding="{Binding Manager.ShortName}"
-                                            Width="9*"/>
+                                            Width="5*"/>
                         <DataGridTextColumn Header="Score" 
                                             Binding="{Binding Manager.Score, StringFormat='\{0:0\}', TargetNullValue='N/A'}"
                                             Width="*"/>
                         <DataGridTextColumn Header="Status" 
                                             Binding="{Binding Manager.Status}"
                                             Width="*"/>
-                        <DataGridTemplateColumn Width="*">
+                        <!--<DataGridTemplateColumn Width="*">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Button Name="buttonAddManager"
@@ -112,8 +118,14 @@
                                     </Button>
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                        </DataGridTemplateColumn>-->
                     </DataGrid.Columns>
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow">
+                            <Setter Property="ToolTip" Value="Double click to move - Press Enter to move selection"/>
+                            <Setter Property="ToolTipService.InitialShowDelay" Value="200"/>
+                        </Style>
+                    </DataGrid.RowStyle>
                 </DataGrid>
             </Grid>
 
@@ -121,53 +133,68 @@
                   Grid.Column="3"
                   Grid.Row="1"
                   Margin="0,-1,0,0">
-                
+
                 <!-- The details tab -->
                 <TabControl Name="TabcontrolStatistics"
                             Background="{DynamicResource BackgroundColor}"
                             BorderBrush="Transparent">
-                    
+
                     <TabItem x:Name="TabInfo"
                              Header="Info"
                              Style="{DynamicResource TabItemStyleOverwrite}"
                              Margin="-2,0,0,0"
                              Height="27">
-                        
+
                         <Grid x:Name="GridInfoTab"
                               Margin="-4,-6,-3,-3">
-                            
                             <DataGrid x:Name="DatagridManagerDetails"
                                       Margin = "0, 3, 0, 0"
                                       Style="{DynamicResource DefaultDatagrid}"
-                                      ItemsSource="{Binding WrappedManagers}"
+                                      ItemsSource="{Binding DetailedManagers}"
                                       HorizontalScrollBarVisibility="Hidden"
                                       HorizontalAlignment="Left"
                                       PreviewKeyDown="DatagridManagersRemove_PreviewKeyDown" 
                                       MouseDoubleClick="DatagridManagersRemove_MouseDoubleClick">
-                                
+
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="ID"
                                                         Binding="{Binding Manager.ContextId}"
-                                                        Width="25pt"/>
-                                    <DataGridTextColumn Header="Start time"
+                                                        Width="0.7*"/>
+                                    <DataGridTextColumn Header="Name" 
+                                                        Binding="{Binding Manager.ShortName}"
+                                                        Width="6*"/>
+                                    <DataGridTextColumn Header="Score" 
+                                                        Binding="{Binding Manager.Score, StringFormat='\{0:0\}', TargetNullValue='N/A'}"
+                                                        Width="*"/>
+                                    <DataGridTextColumn Header="Start"
                                                         Binding="{Binding Manager.StartTime, StringFormat=dd/MM HH:mm:ss, TargetNullValue='N/A'}"
-                                                        Width="2*"/>
-                                    <DataGridTextColumn Header="End time"
+                                                        Width="2.5*"/>
+                                    <DataGridTextColumn Header="End"
                                                         Binding="{Binding Manager.EndTime, StringFormat=dd/MM HH:mm:ss, TargetNullValue='N/A'}"
-                                                        Width="2*"/>
-                                    <DataGridTextColumn Header="Runtime"
+                                                        Width="2.5*"/>
+                                    <DataGridTextColumn Header="Total"
                                                         Binding="{Binding Manager.Runtime, StringFormat=\{0:hh\\:mm\\:ss\}, TargetNullValue='N/A'}"
                                                         Width="2*"/>
                                     <DataGridTextColumn Header="Rows read"
                                                         Binding="{Binding Manager.RowsRead, TargetNullValue='N/A'}"
-                                                        Width="1.5*"/>
+                                                        Width="1.8*"/>
                                     <DataGridTextColumn Header="Rows written"
                                                         Binding="{Binding Manager.RowsWritten, TargetNullValue='N/A'}"
-                                                        Width="1.5*"/>
-                                    <DataGridTemplateColumn>
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <Button Name="buttonRemoveManager"
+                                                        Width="1.8*"/>
+                                </DataGrid.Columns>
+                                <DataGrid.RowStyle>
+                                    <Style TargetType="DataGridRow">
+                                        <Setter Property="ToolTip" Value="Double click to move - Press Enter to move selection"/>
+                                        <Setter Property="ToolTipService.InitialShowDelay" Value="200"/>
+                                    </Style>
+                                </DataGrid.RowStyle>
+                            </DataGrid>
+                        </Grid>
+                    </TabItem>
+                    <!--<DataGridTemplateColumn>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Name="buttonRemoveManager"
                                                         Click="RemoveManager_Click"
                                                         ToolTip="Remove manager from detailed view"
                                                         FontFamily="wingdings 3"
@@ -175,30 +202,27 @@
                                                         Tag="{Binding}"
                                                         Style="{StaticResource DetachButton}"
                                                         Margin="0,0,4,0">
-                                                    <Image Source="../Icons/Remove.png"
+                                    <Image Source="../Icons/Remove.png"
                                                            Margin="8"/>
-                                                </Button>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                </DataGrid.Columns>
-                            </DataGrid>
-                        </Grid>
-                    </TabItem>
-                    
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>-->
+
                     <!-- The charting tab -->
                     <TabItem
                         x:Name="TabPerformance"
                         Header="Performance"
                         Style="{DynamicResource TabItemStyleOverwrite}"
                         Height="27">
-                        
+
                         <Grid x:Name="GridPerformanceTab"
                               Margin="-4,-6,-3,-3">
-                            
+
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="311*"/>
+                                <RowDefinition Height="13*"/>
+                                <RowDefinition Height="325*"/>
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
@@ -206,20 +230,23 @@
                             </Grid.ColumnDefinitions>
 
                             <Grid Grid.Row="0"
-                                  Margin="0,5,0,5">
-                                
+                                  Margin="0,5,0,5" Grid.RowSpan="2">
+
                                 <StackPanel>
                                     <Label Content="CPU Usage"
                                            Style="{DynamicResource ChartLabels}"/>
                                 </StackPanel>
-                                
+
                                 <lvc:CartesianChart DataContext="{Binding ManagerChartViewModel.CPUChart}"
                                                     Grid.Row="1"
                                                     Series="{Binding ChartData.Series}"
                                                     ZoomMode="X"
                                                     XAxes="{Binding ChartData.XAxis}"
                                                     YAxes="{Binding ChartData.YAxis}"
-                                                    TooltipPosition="Center">
+                                                    AnimationsSpeed="0">
+                                    <lvc:CartesianChart.TooltipTemplate>
+                                        <DataTemplate></DataTemplate>
+                                    </lvc:CartesianChart.TooltipTemplate>
                                 </lvc:CartesianChart>
 
                                 <Grid.RowDefinitions>
@@ -228,7 +255,7 @@
                                 </Grid.RowDefinitions>
                             </Grid>
 
-                            <Grid Grid.Row="1"
+                            <Grid Grid.Row="2"
                                   Margin="0,5,0,5">
 
                                 <Grid.RowDefinitions>
@@ -247,15 +274,17 @@
                                                     ZoomMode="X"
                                                     XAxes="{Binding ChartData.XAxis}"
                                                     YAxes="{Binding ChartData.YAxis}"
-                                                    TooltipPosition="Top">
+                                                    AnimationsSpeed="0">
+                                    <lvc:CartesianChart.TooltipTemplate>
+                                        <DataTemplate></DataTemplate>
+                                    </lvc:CartesianChart.TooltipTemplate>
                                 </lvc:CartesianChart>
                             </Grid>
-
                             <DataGrid Name="DatagridManagerCharts"
-                                      ItemsSource="{Binding WrappedManagers}"
                                       Grid.Row="0"
                                       Grid.Column="1"
                                       Grid.RowSpan="4"
+                                      ItemsSource="{Binding DetailedManagers}"
                                       Margin="15,5,0,10"
                                       BorderBrush="Transparent"
                                       Style="{DynamicResource DefaultDatagrid}"
@@ -263,42 +292,55 @@
                                       CanUserResizeColumns="False"
                                       PreviewKeyDown="DatagridManagersRemove_PreviewKeyDown"
                                       MouseDoubleClick="DatagridManagersRemove_MouseDoubleClick">
-                                
-                                <DataGrid.Columns>
-                                    <DataGridTemplateColumn Width="*">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <Rectangle Height="auto"
+
+                                    <DataGrid.Columns>
+                                        <DataGridTemplateColumn Width="*">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <Rectangle Height="auto"
                                                            Width="auto"
                                                            Fill="{Binding LineColor}">
-                                                </Rectangle>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                    <DataGridTextColumn Binding="{Binding Manager.ContextId, FallbackValue='N/A'}"
+                                                    </Rectangle>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridTextColumn Binding="{Binding Manager.ContextId, FallbackValue='N/A'}"
                                                         Header="ID"
                                                         Width="2*"/>
-                                    <DataGridTemplateColumn Width="*">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <Button Name="buttonRemoveManager"
+                                        <DataGridTemplateColumn Width="*">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <Button Name="buttonRemoveManager"
                                                         Click="RemoveManager_Click"
                                                         ToolTip="Remove manager from detailed view"
                                                         Width="20pt"
                                                         FontFamily="wingdings 3"
                                                         Tag="{Binding}"
                                                         Style="{DynamicResource DefaultButton}">
-                                                    <Image Source="../Icons/Remove.png"
+                                                        <Image Source="../Icons/Remove.png"
                                                            Margin="8"/>
-                                                </Button>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                </DataGrid.Columns>
-                            </DataGrid>
+                                                    </Button>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                    </DataGrid.Columns>
+                                    <DataGrid.RowStyle>
+                                        <Style TargetType="DataGridRow">
+                                            <Setter Property="Visibility" Value="{Binding Manager.CpuReadings.Count, Converter={StaticResource CountToVisibilityConverter}}"/>
+                                            <Setter Property="ToolTip" Value="{Binding Manager.ShortName}"/>
+                                            <Setter Property="ToolTipService.InitialShowDelay" Value="200"/>
+                                        </Style>
+                                    </DataGrid.RowStyle>
+                                </DataGrid>
                         </Grid>
                     </TabItem>
                 </TabControl>
+                <TextBlock Text="{Binding HiddenManagers, StringFormat=Managers not shown in chart due to few data points: {0}}" 
+                           Foreground="{DynamicResource ForegroundColor}"
+                           TextWrapping="Wrap" 
+                           FontSize="14"
+                           VerticalAlignment="Top"
+                           HorizontalAlignment="Right"/>
             </Grid>
         </Grid>
     </Border>

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
@@ -42,6 +42,7 @@
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="4.5*"/>
                     <ColumnDefinition Width="35"/>
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
@@ -49,15 +50,31 @@
                     <RowDefinition Height="22*"/>
                 </Grid.RowDefinitions>
 
+                <ComboBox Margin="0 0 2 5"  
+                          ToolTip="Choose which execution to show data from" 
+                          Style="{DynamicResource ComboBoxExecutions}"  
+                          ItemsSource="{Binding Executions}"  
+                          SelectedItem="{Binding SelectedExecution, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}"  
+                                       VerticalAlignment="Center" 
+                                       Foreground="{DynamicResource ForegroundColor}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                
                 <TextBox Name="TextboxSearchbar"
                          Text="{Binding ManagerSearch, UpdateSourceTrigger=PropertyChanged}"
                          Margin="0,0,0,5"
                          ToolTip="Search by manager Name or ID"
-                         Style="{DynamicResource SearchBox}">
+                         Style="{DynamicResource ValidationsSearchBox}"
+                         Grid.Column="1">
                 </TextBox>
 
-                <DockPanel LastChildFill="False">
-                    <Image Source="../Icons/MagnifyingglassAlt.png"
+                <DockPanel LastChildFill="False"
+                           Grid.Column="1">
+                    <Image Source="../Icons/Magnifyingglass.png"
                                Margin="0,2,2,7"
                                DockPanel.Dock="Right"/>
                 </DockPanel>
@@ -65,7 +82,7 @@
                 <Button Name="ButtonResetManagers"
                         Click="ResetManagers_Click"
                         ToolTip="Clear the chosen managers"
-                        Grid.Column="1"
+                        Grid.Column="2"
                         Margin="5,0,0,5"
                         Content="Reset"
                         Style="{DynamicResource DefaultButton}">
@@ -74,7 +91,7 @@
                 <!-- The manager overview datagrid -->
                 <DataGrid x:Name="DatagridManagers"
                           Grid.Row="1"
-                          Grid.ColumnSpan="2"
+                          Grid.ColumnSpan="3"
                           Style="{DynamicResource DefaultDatagrid}"
                           BorderBrush="{DynamicResource BorderColor}"
                           ItemsSource="{Binding Managers}" 

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
@@ -50,7 +50,7 @@
                 </Grid.RowDefinitions>
 
                 <TextBox Name="TextboxSearchbar"
-                         TextChanged="TextboxSearchbar_TextChanged"
+                         Text="{Binding ManagerSearch, UpdateSourceTrigger=PropertyChanged}"
                          Margin="0,0,0,5"
                          ToolTip="Search by manager Name or ID"
                          Style="{DynamicResource SearchBox}">
@@ -80,7 +80,7 @@
                           ItemsSource="{Binding Managers}" 
                           HorizontalScrollBarVisibility="Hidden"
                           HorizontalAlignment="Left">
-                    
+
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ID" 
                                             Binding="{Binding Manager.ContextId}"
@@ -94,7 +94,7 @@
                         <DataGridTextColumn Header="Status" 
                                             Binding="{Binding Manager.Status}"
                                             Width="*"/>
-                        <DataGridTemplateColumn>
+                        <DataGridTemplateColumn Width="*">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Button Name="buttonAddManager"
@@ -104,7 +104,7 @@
                                             Width="20pt"
                                             Tag="{Binding}"
                                             Style="{StaticResource ManagerButton}"
-                                            Margin="0,0,4,0">
+                                            Margin="2,0,2,0">
                                         <Image Source="../Icons/Add.png"
                                                Margin="8"/>
                                     </Button>
@@ -255,10 +255,11 @@
                                       Margin="15,5,0,10"
                                       BorderBrush="Transparent"
                                       Style="{DynamicResource DefaultDatagrid}"
-                                      Background="{DynamicResource BackgroundColor}">
+                                      Background="{DynamicResource BackgroundColor}"
+                                      CanUserResizeColumns="False">
                                 
                                 <DataGrid.Columns>
-                                    <DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Width="*">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <Rectangle Height="auto"
@@ -270,8 +271,8 @@
                                     </DataGridTemplateColumn>
                                     <DataGridTextColumn Binding="{Binding Manager.ContextId, FallbackValue='N/A'}"
                                                         Header="ID"
-                                                        Width="30pt"/>
-                                    <DataGridTemplateColumn>
+                                                        Width="2*"/>
+                                    <DataGridTemplateColumn Width="*">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <Button Name="buttonRemoveManager"

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
@@ -77,7 +77,9 @@
                           Grid.ColumnSpan="2"
                           Style="{DynamicResource DefaultDatagrid}"
                           BorderBrush="{DynamicResource BorderColor}"
-                          ItemsSource="{Binding Managers}" 
+                          ItemsSource="{Binding Managers}"
+                          PreviewKeyDown="DatagridManagersAdd_PreviewKeyDown"
+                          MouseDoubleClick="DatagridManagersAdd_MouseDoubleClick"
                           HorizontalScrollBarVisibility="Hidden"
                           HorizontalAlignment="Left">
 
@@ -139,7 +141,9 @@
                                       Style="{DynamicResource DefaultDatagrid}"
                                       ItemsSource="{Binding WrappedManagers}"
                                       HorizontalScrollBarVisibility="Hidden"
-                                      HorizontalAlignment="Left">
+                                      HorizontalAlignment="Left"
+                                      PreviewKeyDown="DatagridManagersRemove_PreviewKeyDown" 
+                                      MouseDoubleClick="DatagridManagersRemove_MouseDoubleClick">
                                 
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="ID"
@@ -256,7 +260,9 @@
                                       BorderBrush="Transparent"
                                       Style="{DynamicResource DefaultDatagrid}"
                                       Background="{DynamicResource BackgroundColor}"
-                                      CanUserResizeColumns="False">
+                                      CanUserResizeColumns="False"
+                                      PreviewKeyDown="DatagridManagersRemove_PreviewKeyDown"
+                                      MouseDoubleClick="DatagridManagersRemove_MouseDoubleClick">
                                 
                                 <DataGrid.Columns>
                                     <DataGridTemplateColumn Width="*">

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml
@@ -109,16 +109,16 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ID" 
                                             Binding="{Binding Manager.ContextId}"
-                                            Width="0.5*"/>
+                                            Width="0.7*"/>
                         <DataGridTextColumn Header="Name" 
                                             Binding="{Binding Manager.ShortName}"
                                             Width="5*"/>
                         <DataGridTextColumn Header="Score" 
                                             Binding="{Binding Manager.Score, StringFormat='\{0:0\}', TargetNullValue='N/A'}"
-                                            Width="*"/>
+                                            Width="1.1*"/>
                         <DataGridTextColumn Header="Status" 
                                             Binding="{Binding Manager.Status}"
-                                            Width="*"/>
+                                            Width="1.1*"/>
                         <!--<DataGridTemplateColumn Width="*">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
@@ -176,13 +176,13 @@
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="ID"
                                                         Binding="{Binding Manager.ContextId}"
-                                                        Width="0.7*"/>
+                                                        Width="0.8*"/>
                                     <DataGridTextColumn Header="Name" 
                                                         Binding="{Binding Manager.ShortName}"
                                                         Width="6*"/>
                                     <DataGridTextColumn Header="Score" 
                                                         Binding="{Binding Manager.Score, StringFormat='\{0:0\}', TargetNullValue='N/A'}"
-                                                        Width="*"/>
+                                                        Width="1.2*"/>
                                     <DataGridTextColumn Header="Start"
                                                         Binding="{Binding Manager.StartTime, StringFormat=dd/MM HH:mm:ss, TargetNullValue='N/A'}"
                                                         Width="2.5*"/>
@@ -194,10 +194,10 @@
                                                         Width="2*"/>
                                     <DataGridTextColumn Header="Rows read"
                                                         Binding="{Binding Manager.RowsRead, TargetNullValue='N/A'}"
-                                                        Width="1.8*"/>
+                                                        Width="1.9*"/>
                                     <DataGridTextColumn Header="Rows written"
                                                         Binding="{Binding Manager.RowsWritten, TargetNullValue='N/A'}"
-                                                        Width="1.8*"/>
+                                                        Width="2.2*"/>
                                 </DataGrid.Columns>
                                 <DataGrid.RowStyle>
                                     <Style TargetType="DataGridRow">

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
@@ -34,7 +34,7 @@ namespace DashboardFrontend.DetachedWindows
             List<ManagerWrapper> managers = new();
             foreach (ManagerWrapper manager in DatagridManagers.SelectedItems)
             {
-                if (!Vm.DetailedManagers.Any(m => m.Manager.ContextId == manager.Manager.ContextId))
+                if (!Vm.DetailedManagers.Any(m => m.Manager.Name == manager.Manager.Name))
                 {
                     DatagridManagerMover("Add", manager);
                 }

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 
 namespace DashboardFrontend.DetachedWindows
 {
@@ -30,13 +31,18 @@ namespace DashboardFrontend.DetachedWindows
         /// <param name="e"></param>
         private void AddManager_Click(object sender, RoutedEventArgs e)
         {
+            List<ManagerWrapper> managers = new();
             foreach (ManagerWrapper manager in DatagridManagers.SelectedItems)
             {
-                if (!Vm.WrappedManagers.Any(e => e.Manager.ContextId == manager.Manager.ContextId))
+                if (!Vm.DetailedManagers.Any(m => m.Manager.ContextId == manager.Manager.ContextId))
                 {
                     DatagridManagerMover("Add", manager);
-                    manager.IsDetailedInfoShown = true;
                 }
+                managers.Add(manager);
+            }
+            foreach (var manager in managers)
+            {
+                Vm.Managers.Remove(manager);
             }
         }
 
@@ -55,7 +61,7 @@ namespace DashboardFrontend.DetachedWindows
             foreach (ManagerWrapper manager in managers) //You cannot iterate through the datagrid while also removing from the datagrid.
             {
                 DatagridManagerMover("Remove", manager);
-                manager.IsDetailedInfoShown = false;
+                Vm.Managers.Add(manager);
             }
         }
 
@@ -79,17 +85,22 @@ namespace DashboardFrontend.DetachedWindows
             switch (method)
             {
                 case "Add" when manager is not null:
-                    Vm.WrappedManagers.Add(manager);
+                    manager.IsDetailedInfoShown = true;
+                    Vm.DetailedManagers.Add(manager);
+                    Vm.UpdateHiddenManagers();
                     Vm.ManagerChartViewModel.AddChartLinesHelper(manager);
                     break;
 
                 case "Remove" when manager is not null:
-                    Vm.WrappedManagers.Remove(manager);
+                    manager.IsDetailedInfoShown = false;
+                    Vm.DetailedManagers.Remove(manager);
+                    Vm.UpdateHiddenManagers();
                     Vm.ManagerChartViewModel.RemoveChartLinesHelper(manager);
                     break;
 
                 case "Clear":
-                    Vm.WrappedManagers.Clear();
+                    Vm.DetailedManagers.Clear();
+                    Vm.UpdateHiddenManagers();
                     Vm.ManagerChartViewModel.ClearChartLinesHelper();
                     break;
             }

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
@@ -94,5 +94,33 @@ namespace DashboardFrontend.DetachedWindows
                     break;
             }
         }
+
+        private void DatagridManagersAdd_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                e.Handled = true;
+                AddManager_Click(sender, e);
+            }
+        }
+
+        private void DatagridManagersAdd_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            AddManager_Click((object)sender, e);
+        }
+
+        private void DatagridManagersRemove_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                e.Handled = true;
+                RemoveManager_Click(sender, e);
+            }
+        }
+
+        private void DatagridManagersRemove_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            RemoveManager_Click((object)sender, e);
+        }
     }
 }

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
@@ -99,6 +99,10 @@ namespace DashboardFrontend.DetachedWindows
                     break;
 
                 case "Clear":
+                    foreach (var wrapper in Vm.DetailedManagers)
+                    {
+                        Vm.Managers.Add(wrapper);
+                    }
                     Vm.DetailedManagers.Clear();
                     Vm.UpdateHiddenManagers();
                     Vm.ManagerChartViewModel.ClearChartLinesHelper();
@@ -117,6 +121,7 @@ namespace DashboardFrontend.DetachedWindows
 
         private void DatagridManagersAdd_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            if ((e.OriginalSource as FrameworkElement)?.Parent is not DataGridCell) return;
             AddManager_Click((object)sender, e);
         }
 
@@ -131,6 +136,7 @@ namespace DashboardFrontend.DetachedWindows
 
         private void DatagridManagersRemove_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            if ((e.OriginalSource as FrameworkElement)?.Parent is not DataGridCell) return;
             RemoveManager_Click((object)sender, e);
         }
     }

--- a/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
+++ b/DashboardFrontend/DetachedWindows/ManagerListDetached.xaml.cs
@@ -70,28 +70,6 @@ namespace DashboardFrontend.DetachedWindows
         }
 
         /// <summary>
-        /// Searches through the manager overview based on the text present in the searchbar.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void TextboxSearchbar_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            DatagridManagers.SelectedItems.Clear();
-            if (TextboxSearchbar.Text != null)
-            {
-                List<ManagerWrapper> foundManagers = new();
-                foreach (ManagerWrapper manager in DatagridManagers.Items)
-                {
-                    if (manager.Manager.Name.Contains(TextboxSearchbar.Text) || manager.Manager.ContextId.ToString() == TextboxSearchbar.Text)
-                    {
-                        foundManagers.Add(manager);
-                        DatagridManagers.SelectedItems.Add(manager);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
         /// Helper function assembling all the manager mover functionality.
         /// </summary>
         /// The function to be done to the manager <param name="method"></param>

--- a/DashboardFrontend/DetachedWindows/NewProfileWindow.xaml.cs
+++ b/DashboardFrontend/DetachedWindows/NewProfileWindow.xaml.cs
@@ -85,6 +85,10 @@ namespace DashboardFrontend.DetachedWindows
                 if (!UserSettings.Profiles.Contains(Profile))
                 {
                     UserSettings.Profiles.Add(Profile);
+                    if (UserSettings.ActiveProfile is null)
+                    {
+                        UserSettings.ActiveProfile = Profile;
+                    }
                 }
 
                 if (ProfileDataChanged)

--- a/DashboardFrontend/MainWindow.xaml
+++ b/DashboardFrontend/MainWindow.xaml
@@ -213,7 +213,6 @@
                               BorderBrush="{DynamicResource BorderColor}"
                               HorizontalScrollBarVisibility="Hidden"
                               HorizontalAlignment="Left">
-
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="ID" 
                                                 Binding="{Binding Manager.ContextId}"
@@ -319,8 +318,7 @@
                         <ToggleButton Name="ButtonLogFilter"
                                 Grid.Column="9"
                                 Style="{DynamicResource FilterButton}"
-                                Margin="0, 0, 0, -1"
-                                IsEnabled="{Binding ElementName=PopupLogFilter, Path=IsOpen}">
+                                Margin="0, 0, 0, -1">
                             <Image Source="Icons/Filter.png"/>
                         </ToggleButton>
 

--- a/DashboardFrontend/MainWindow.xaml
+++ b/DashboardFrontend/MainWindow.xaml
@@ -211,6 +211,7 @@
                               Grid.ColumnSpan="3"
                               Style="{DynamicResource DefaultDatagrid}"
                               BorderBrush="{DynamicResource BorderColor}"
+                              MouseDoubleClick="DatagridManagers_MouseDoubleClick"
                               HorizontalScrollBarVisibility="Hidden"
                               HorizontalAlignment="Left">
                         <DataGrid.Columns>

--- a/DashboardFrontend/MainWindow.xaml
+++ b/DashboardFrontend/MainWindow.xaml
@@ -167,6 +167,7 @@
                       DataContext="{Binding ManagerViewModel}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="4.5*"/>
                         <ColumnDefinition Width="30"/>
                         <ColumnDefinition Width="30"/>
                     </Grid.ColumnDefinitions>
@@ -175,23 +176,38 @@
                         <RowDefinition Height="22*"/>
                     </Grid.RowDefinitions>
 
+                    <ComboBox Margin="0 2 2 2"  
+                              ToolTip="Choose which execution to show data from" 
+                              Style="{DynamicResource ComboBoxExecutions}"  
+                              ItemsSource="{Binding Executions}"  
+                              SelectedItem="{Binding SelectedExecution, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Id, StringFormat='Execution {0}'}"  
+                                           VerticalAlignment="Center" 
+                                           Foreground="{DynamicResource ForegroundColor}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+
                     <TextBox Name="textboxManagerSearchbar"
                              Text="{Binding ManagerSearch, UpdateSourceTrigger=PropertyChanged}"
                              ToolTip="Search by manager Name or ID"
-                             Height="26"
-                             Style="{DynamicResource SearchBox}"
+                             Style="{DynamicResource ValidationsSearchBox}"
+                             Grid.Column="1"
                              Margin="0,0,0,1"
                              BorderBrush="{DynamicResource BorderColor}">
                     </TextBox>
 
-                    <DockPanel LastChildFill="False">
-                        <Image Source="Icons/MagnifyingglassAlt.png"
+                    <DockPanel LastChildFill="False"
+                               Grid.Column="1">
+                        <Image Source="Icons/Magnifyingglass.png"
                                Margin="0,5,10,5"
                                DockPanel.Dock="Right"/>
                     </DockPanel>
 
                     <ToggleButton Name="ButtonManagerFilter"
-                            Grid.Column="1"
+                            Grid.Column="2"
                             Margin="0, 0, 0, 1"
                             Style="{DynamicResource FilterButton}">
                         <Image Source="Icons/Filter.png"/>
@@ -199,7 +215,7 @@
 
                     <Button Name="ButtonDetachManager"
                             Click="DetachManagerButtonClick"
-                            Grid.Column="2"
+                            Grid.Column="3"
                             Margin="0, -2, -2, 0"
                             Style="{StaticResource DetachButton}">
                         <Image Source="Icons/Detach.png"/>
@@ -208,7 +224,7 @@
                     <DataGrid x:Name="datagridManagers"
                               ItemsSource="{Binding Managers}"
                               Grid.Row="1"
-                              Grid.ColumnSpan="3"
+                              Grid.ColumnSpan="4"
                               Style="{DynamicResource DefaultDatagrid}"
                               BorderBrush="{DynamicResource BorderColor}"
                               HorizontalScrollBarVisibility="Hidden"
@@ -634,9 +650,7 @@
                                          Margin="2"
                                          Style="{DynamicResource ValidationsSearchBox}"
                                          Text="{Binding NameFilter, UpdateSourceTrigger=PropertyChanged}"
-                                         ToolTip="Search for managers by their name or context ID"
-                                         Foreground="{DynamicResource ForegroundColor}"
-                                         CaretBrush="{DynamicResource ForegroundColor}"/>
+                                         ToolTip="Search for managers by their name or context ID"/>
 
                                 <Image Source="/Icons/Magnifyingglass.png"
                                        Grid.Column="1"

--- a/DashboardFrontend/MainWindow.xaml
+++ b/DashboardFrontend/MainWindow.xaml
@@ -236,13 +236,13 @@
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="ID" 
                                                 Binding="{Binding Manager.ContextId}"
-                                                Width="25pt"/>
+                                                Width="32pt"/>
                             <DataGridTextColumn Header="Manager name" 
                                                 Binding="{Binding Manager.ShortName}"
                                                 Width="8*"/>
                             <DataGridTextColumn Header="Score" 
                                                 Binding="{Binding Manager.Score, StringFormat='\{0:0\}', TargetNullValue='N/A'}"
-                                                Width="*"/>
+                                                Width="1.3*"/>
                             <DataGridTextColumn Header="Status" 
                                                 Binding="{Binding Manager.Status}"
                                                 Width="2*"/>

--- a/DashboardFrontend/MainWindow.xaml
+++ b/DashboardFrontend/MainWindow.xaml
@@ -36,6 +36,9 @@
             <Setter Property="Background" Value="{DynamicResource CanvasColor}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}"/>
         </Style>
+        <Style TargetType="{x:Type lvc:CartesianChart}">
+            <Setter Property="Cursor" Value="Cross"/>
+        </Style>
     </Window.Resources>
     <Border Background="{DynamicResource BackgroundColor}">
         <Grid>
@@ -228,6 +231,12 @@
                                                 Binding="{Binding Manager.Status}"
                                                 Width="2*"/>
                         </DataGrid.Columns>
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow">
+                                <Setter Property="ToolTip" Value="Double click to open view"/>
+                                <Setter Property="ToolTipService.InitialShowDelay" Value="200"/>
+                            </Style>
+                        </DataGrid.RowStyle>
                     </DataGrid>
                 </Grid>
 
@@ -425,6 +434,7 @@
                                     <Setter Property="FontSize" Value="14"/>
                                     <Setter Property="Focusable" Value="False"/>
                                     <Setter Property="ToolTip" Value="{Binding ManagerName, TargetNullValue='Context not found'}"/>
+                                    <Setter Property="ToolTipService.InitialShowDelay" Value="200"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding Type}" Value="Info">
                                             <Setter Property="Foreground" Value="{DynamicResource LogMessageInfoColor}"/>
@@ -1028,6 +1038,7 @@
 
             <Control Name="ControlLoadingAnim"
                      Visibility="{Binding LoadingVisibility, UpdateSourceTrigger=PropertyChanged, FallbackValue=Collapsed}"
+                     Cursor="Wait"
                      Grid.ColumnSpan="2"
                      Grid.RowSpan="2"
                      Margin="0,100,0,0"

--- a/DashboardFrontend/MainWindow.xaml.cs
+++ b/DashboardFrontend/MainWindow.xaml.cs
@@ -8,9 +8,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Threading.Tasks;
 using DashboardFrontend.Charts;
-using LiveChartsCore.SkiaSharpView.WPF;
 
 namespace DashboardFrontend
 {
@@ -22,7 +20,7 @@ namespace DashboardFrontend
             MaxHeight = SystemParameters.WorkArea.Height;
             MaxWidth = SystemParameters.WorkArea.Width;
             InitializeComponent();
-            ViewModel = new(ListViewLog);
+            ViewModel = new(ListViewLog, this);
             ViewModel.ManagerViewModel.DataGridManagers = datagridManagers;
             DataContext = ViewModel;
         }
@@ -52,6 +50,7 @@ namespace DashboardFrontend
         {
             ManagerViewModel detachedManagerViewModel = ViewModel.Controller.CreateManagerViewModel();
             ManagerListDetached detachedManagerWindow = new(detachedManagerViewModel);
+            detachedManagerViewModel.Window = detachedManagerWindow;
             detachedManagerViewModel.DataGridManagers = detachedManagerWindow.DatagridManagers;
             detachedManagerWindow.Show();
             detachedManagerWindow.Closed += delegate
@@ -299,6 +298,26 @@ namespace DashboardFrontend
                 ButtonLogFilter.IsChecked = false;
                 this.RemoveHandler(UIElement.MouseDownEvent, (MouseButtonEventHandler)GridPopupLogFilter_PreviewMouseDown);
             }
+        }
+
+        private void DatagridManagers_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            ManagerViewModel vm;
+            if (ViewModel.Controller.ManagerViewModels.Count > 1)
+            {
+                vm = ViewModel.Controller.ManagerViewModels[1];
+            }
+            else
+            {
+                DetachManagerButtonClick(this, null);
+                vm = ViewModel.Controller.ManagerViewModels[1];
+            }
+            vm.Window.Activate();
+            vm.DataGridManagers.SelectedItem = vm.DataGridManagers.Items[datagridManagers.SelectedIndex];
+            MouseButtonEventArgs doubleClickEvent = new MouseButtonEventArgs(Mouse.PrimaryDevice, (int)DateTime.Now.Ticks, MouseButton.Left);
+            doubleClickEvent.RoutedEvent = Control.MouseDoubleClickEvent;
+            doubleClickEvent.Source = this;
+            vm.DataGridManagers.RaiseEvent(doubleClickEvent);
         }
     }
 }

--- a/DashboardFrontend/MainWindow.xaml.cs
+++ b/DashboardFrontend/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using DashboardFrontend.Charts;
+using System.Linq;
 
 namespace DashboardFrontend
 {
@@ -300,7 +301,7 @@ namespace DashboardFrontend
             }
         }
 
-        private void DatagridManagers_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        private async void DatagridManagers_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             ManagerViewModel vm;
             if (ViewModel.Controller.ManagerViewModels.Count > 1)
@@ -312,12 +313,21 @@ namespace DashboardFrontend
                 DetachManagerButtonClick(this, null);
                 vm = ViewModel.Controller.ManagerViewModels[1];
             }
+            await Task.Delay(5);
             vm.Window.Activate();
-            vm.DataGridManagers.SelectedItem = vm.DataGridManagers.Items[datagridManagers.SelectedIndex];
-            MouseButtonEventArgs doubleClickEvent = new MouseButtonEventArgs(Mouse.PrimaryDevice, (int)DateTime.Now.Ticks, MouseButton.Left);
-            doubleClickEvent.RoutedEvent = Control.MouseDoubleClickEvent;
-            doubleClickEvent.Source = this;
-            vm.DataGridManagers.RaiseEvent(doubleClickEvent);
+            var wrapper = (ManagerWrapper)datagridManagers.SelectedItem;
+            var foreignManager = vm.Managers.FirstOrDefault(m => m.Manager.ContextId == wrapper.Manager.ContextId);
+            if (foreignManager != null)
+            {
+                vm.Managers.Remove(foreignManager);
+                if (!vm.DetailedManagers.Contains(foreignManager))
+                {
+                    vm.DetailedManagers.Add(foreignManager);
+                    vm.UpdateHiddenManagers();
+                    foreignManager.IsDetailedInfoShown = true;
+                    vm.ManagerChartViewModel.AddChartLinesHelper(foreignManager);
+                }
+            }
         }
     }
 }

--- a/DashboardFrontend/MainWindow.xaml.cs
+++ b/DashboardFrontend/MainWindow.xaml.cs
@@ -47,7 +47,7 @@ namespace DashboardFrontend
             settingsWindow.ShowDialog();
         }
 
-        public void DetachManagerButtonClick(object sender, RoutedEventArgs e)
+        public async void DetachManagerButtonClick(object sender, RoutedEventArgs e)
         {
             ManagerViewModel detachedManagerViewModel = ViewModel.Controller.CreateManagerViewModel();
             ManagerListDetached detachedManagerWindow = new(detachedManagerViewModel);
@@ -63,9 +63,12 @@ namespace DashboardFrontend
                     ViewModel.Controller.ManagerViewModels.Remove(detachedManagerViewModel);
                 });
             };
+            await Task.Delay(5);
+            int selectedExecutionId = ViewModel.ManagerViewModel.SelectedExecution.Id;
+            detachedManagerViewModel.SelectedExecution = detachedManagerViewModel.Executions[selectedExecutionId - 1];
         }
 
-        public void DetachLogButtonClick(object sender, RoutedEventArgs e)
+        public async void DetachLogButtonClick(object sender, RoutedEventArgs e)
         {
             LogViewModel detachedLogViewModel = ViewModel.Controller.CreateLogViewModel();
             LogDetached detachLog = new(detachedLogViewModel);
@@ -78,9 +81,12 @@ namespace DashboardFrontend
                     ViewModel.Controller.LogViewModels.Remove(detachedLogViewModel);
                 });
             };
+            await Task.Delay(5);
+            int selectedExecutionId = ViewModel.LogViewModel.SelectedExecution.Id;
+            detachedLogViewModel.SelectedExecution = detachedLogViewModel.Executions[selectedExecutionId - 1];
         }
 
-        public void DetachValidationReportButtonClick(object sender, RoutedEventArgs e)
+        public async void DetachValidationReportButtonClick(object sender, RoutedEventArgs e)
         {
             ValidationReportViewModel detachedValidationReportViewModel =
                 ViewModel.Controller.CreateValidationReportViewModel();
@@ -94,6 +100,9 @@ namespace DashboardFrontend
                     ViewModel.Controller.ValidationReportViewModels.Remove(detachedValidationReportViewModel);
                 });
             };
+            await Task.Delay(5);
+            int selectedExecutionId = ViewModel.ValidationReportViewModel.SelectedExecution.Id;
+            detachedValidationReportViewModel.SelectedExecution = detachedValidationReportViewModel.Executions[selectedExecutionId - 1];
         }
 
         public void DetachHealthReportButtonClick(object sender, RoutedEventArgs e)
@@ -303,33 +312,7 @@ namespace DashboardFrontend
 
         private async void DatagridManagers_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            ManagerViewModel vm;
-            int selectedExecutionId = ViewModel.ManagerViewModel.SelectedExecution.Id;
-            if (ViewModel.Controller.ManagerViewModels.Skip(1).Any(vm => vm.SelectedExecution.Id == selectedExecutionId))
-            {
-                vm = ViewModel.Controller.ManagerViewModels.Skip(1).First(vm => vm.SelectedExecution.Id == selectedExecutionId);
-            }
-            else
-            {
-                DetachManagerButtonClick(this, null);
-                vm = ViewModel.Controller.ManagerViewModels.Last();
-                await Task.Delay(5);
-                vm.SelectedExecution = vm.Executions.First(exec => exec.Id == selectedExecutionId);
-            }
-            vm.Window.Activate();
-            var wrapper = (ManagerWrapper)datagridManagers.SelectedItem;
-            var foreignManager = vm.Managers.FirstOrDefault(m => m.Manager.ContextId == wrapper.Manager.ContextId);
-            if (foreignManager != null)
-            {
-                vm.Managers.Remove(foreignManager);
-                if (!vm.DetailedManagers.Contains(foreignManager))
-                {
-                    vm.DetailedManagers.Add(foreignManager);
-                    vm.UpdateHiddenManagers();
-                    foreignManager.IsDetailedInfoShown = true;
-                    vm.ManagerChartViewModel.AddChartLinesHelper(foreignManager);
-                }
-            }
+            ViewModel.Controller.ExpandManagerView((ManagerWrapper)datagridManagers.SelectedItem);
         }
     }
 }

--- a/DashboardFrontend/MainWindow.xaml.cs
+++ b/DashboardFrontend/MainWindow.xaml.cs
@@ -23,7 +23,7 @@ namespace DashboardFrontend
             MaxWidth = SystemParameters.WorkArea.Width;
             InitializeComponent();
             ViewModel = new(ListViewLog);
-            ViewModel.ManagerViewModel.DatagridManagers = datagridManagers;
+            ViewModel.ManagerViewModel.DataGridManagers = datagridManagers;
             DataContext = ViewModel;
         }
 
@@ -51,10 +51,10 @@ namespace DashboardFrontend
         public void DetachManagerButtonClick(object sender, RoutedEventArgs e)
         {
             ManagerViewModel detachedManagerViewModel = ViewModel.Controller.CreateManagerViewModel();
-            ManagerListDetached detachManager = new(detachedManagerViewModel);
-            detachedManagerViewModel.DatagridManagers = detachManager.DatagridManagers;
-            detachManager.Show();
-            detachManager.Closed += delegate
+            ManagerListDetached detachedManagerWindow = new(detachedManagerViewModel);
+            detachedManagerViewModel.DataGridManagers = detachedManagerWindow.DatagridManagers;
+            detachedManagerWindow.Show();
+            detachedManagerWindow.Closed += delegate
             {
                 // Ensures that the ViewModel is only removed from the controller after its data has been modified, preventing an InvalidOperationException.
                 _ = Task.Run(() =>

--- a/DashboardFrontend/MainWindow.xaml.cs
+++ b/DashboardFrontend/MainWindow.xaml.cs
@@ -23,6 +23,7 @@ namespace DashboardFrontend
             MaxWidth = SystemParameters.WorkArea.Width;
             InitializeComponent();
             ViewModel = new(ListViewLog);
+            ViewModel.ManagerViewModel.DatagridManagers = datagridManagers;
             DataContext = ViewModel;
         }
 
@@ -51,6 +52,7 @@ namespace DashboardFrontend
         {
             ManagerViewModel detachedManagerViewModel = ViewModel.Controller.CreateManagerViewModel();
             ManagerListDetached detachManager = new(detachedManagerViewModel);
+            detachedManagerViewModel.DatagridManagers = detachManager.DatagridManagers;
             detachManager.Show();
             detachManager.Closed += delegate
             {

--- a/DashboardFrontend/MainWindow.xaml.cs
+++ b/DashboardFrontend/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace DashboardFrontend
                 });
             };
             await Task.Delay(5);
+            if (ViewModel.ManagerViewModel.SelectedExecution == null) return;
             int selectedExecutionId = ViewModel.ManagerViewModel.SelectedExecution.Id;
             detachedManagerViewModel.SelectedExecution = detachedManagerViewModel.Executions[selectedExecutionId - 1];
         }

--- a/DashboardFrontend/Settings/Profile.cs
+++ b/DashboardFrontend/Settings/Profile.cs
@@ -25,7 +25,7 @@ namespace DashboardFrontend.Settings
             _nextId = id + 1;
         }
 
-        public Profile() : this("", "", "", "", 30)
+        public Profile() : this("", "", "", "", 5)
         {
         }
 

--- a/DashboardFrontend/Settings/UserSettings.cs
+++ b/DashboardFrontend/Settings/UserSettings.cs
@@ -39,11 +39,11 @@ namespace DashboardFrontend.Settings
                 OnPropertyChanged(nameof(ActiveProfile));
             }
         }
-        public int LoggingQueryInterval { get; set; } = 15; // seconds
+        public int LoggingQueryInterval { get; set; } = 1; // seconds
         public int HealthReportQueryInterval { get; set; } = 30;
-        public int ValidationQueryInterval { get; set; } = 120;
-        public int ManagerQueryInterval { get; set; } = 60;
-        public int AllQueryInterval { get; set; } = 30;
+        public int ValidationQueryInterval { get; set; } = 5;
+        public int ManagerQueryInterval { get; set; } = 5;
+        public int AllQueryInterval { get; set; } = 2;
         public bool SynchronizeAllQueries { get; set; } = false;
         [JsonIgnore]
         public bool HasActiveProfile => ActiveProfile is not null;

--- a/DashboardFrontend/StyleResources/DictionaryDatagrid.xaml
+++ b/DashboardFrontend/StyleResources/DictionaryDatagrid.xaml
@@ -1,6 +1,16 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <Style TargetType="{x:Type Thumb}" x:Key="ThumbStyle">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Thumb}">
+                    <Rectangle Width="1" Stroke="Transparent" Cursor="SizeWE"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="DefaultDatagrid" TargetType="DataGrid">
         <Setter Property="HeadersVisibility" Value="Column"/>
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
@@ -24,12 +34,55 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <Style TargetType="{x:Type DataGridColumnHeader}">
+            <Style TargetType="DataGridColumnHeader">
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="MinWidth" Value="0"/>
+                <Setter Property="MinHeight" Value="0"/>
+                <Setter Property="MaxHeight" Value="30"/>
                 <Setter Property="Background" Value="{DynamicResource HeaderColor}"/>
-                <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}"/>
+                <Setter Property="Cursor" Value="Hand"/>
                 <Setter Property="FontSize" Value="14"/>
                 <Setter Property="Padding" Value="3,0,0,0"/>
+                <Setter Property="Margin" Value="0,0,0,0"/>
+                <Setter Property="BorderThickness" Value="0 0 0 0"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource BackgroundColor}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
+                <Setter Property="HorizontalContentAlignment" Value="Left" />
+                <Setter Property="TextBlock.TextAlignment" Value="Left" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="DataGridColumnHeader">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter Margin="5" VerticalAlignment="Center" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                                <Path x:Name="SortArrow" Visibility="Collapsed" Data="M 0,0 L 1,0 0.5,1 z" Stretch="Fill"
+                                      Grid.Column="1" Width="8" Height="6" Fill="{DynamicResource ForegroundColor}"
+                                      VerticalAlignment="Center" RenderTransformOrigin="0.5, 0.4" Margin="0,0,5,0"/>
+                                <Thumb x:Name="PART_LeftHeaderGripper" HorizontalAlignment="Left" Style="{StaticResource ThumbStyle}"/>
+                                <Thumb x:Name="PART_RightHeaderGripper" Grid.Column="1" HorizontalAlignment="Right" Style="{StaticResource ThumbStyle}"/>
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="SortDirection" Value="Ascending">
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="SortArrow" Property="RenderTransform">
+                                        <Setter.Value>
+                                            <RotateTransform Angle="180"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                                <Trigger Property="SortDirection" Value="Descending">
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                </Trigger>
+                                <Trigger Property="DisplayIndex" Value="0">
+                                    <Setter TargetName="PART_LeftHeaderGripper" Property="Visibility" Value="Collapsed"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
             <Style TargetType="{x:Type ScrollBar}">
                 <Setter Property="Background" Value="{DynamicResource HeaderColor}"/>
@@ -37,5 +90,4 @@
             </Style>
         </Style.Resources>
     </Style>
-    
 </ResourceDictionary>

--- a/DashboardFrontend/StyleResources/DictionaryGeneral.xaml
+++ b/DashboardFrontend/StyleResources/DictionaryGeneral.xaml
@@ -42,6 +42,8 @@
     <Style TargetType="{x:Type TextBox}" x:Key="ValidationsSearchBox">
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource ForegroundColor}"/>
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="FontSize" Value="14"/>

--- a/DashboardFrontend/ValueConverters/CountToVisibilityConverter.cs
+++ b/DashboardFrontend/ValueConverters/CountToVisibilityConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace DashboardFrontend.ValueConverters
+{
+    public class CountToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (int)value > 1 ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return new NotImplementedException();
+        }
+    }
+}

--- a/DashboardFrontend/ValueConverters/FilterPopupHeightConverter.cs
+++ b/DashboardFrontend/ValueConverters/FilterPopupHeightConverter.cs
@@ -9,7 +9,7 @@ namespace DashboardFrontend.ValueConverters
         {
             if (value is double distance)
             {
-                return distance - 120;
+                return distance - 120 > 0 ? distance - 120 : 0;
             }
             else return 0;
         }

--- a/DashboardFrontend/ViewModels/ExecutionObservable.cs
+++ b/DashboardFrontend/ViewModels/ExecutionObservable.cs
@@ -14,7 +14,11 @@ namespace DashboardFrontend.ViewModels
             Id = exec.Id;
             StartTime = exec.StartTime;
 
-            Managers = new(exec.Managers.Select(m => new ManagerObservable(m)));
+            Managers = new();
+            for(int i = 0; i < exec.Managers.Count; i++)
+            {
+                Managers.Add(new ManagerObservable(exec.Managers[i]));
+            }
 
             LogMessages = new(exec.Log.Messages);
         }

--- a/DashboardFrontend/ViewModels/ExecutionObservable.cs
+++ b/DashboardFrontend/ViewModels/ExecutionObservable.cs
@@ -13,7 +13,7 @@ namespace DashboardFrontend.ViewModels
         {
             Id = exec.Id;
             StartTime = exec.StartTime;
-            lock(Managers)
+            lock (executionLock)
             {
                 Managers = new(exec.Managers.Select(m => new ManagerObservable(m)));
             }
@@ -36,6 +36,7 @@ namespace DashboardFrontend.ViewModels
 
         public DateTime? StartTime { get; set; }
         private int _failedTotalCount;
+        private readonly object executionLock = new();
         public int FailedTotalCount
         {
             get => _failedTotalCount; set

--- a/DashboardFrontend/ViewModels/ExecutionObservable.cs
+++ b/DashboardFrontend/ViewModels/ExecutionObservable.cs
@@ -1,9 +1,9 @@
 ﻿using Model;
 using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using static Model.ValidationTest;
-using System.ComponentModel;
 
 namespace DashboardFrontend.ViewModels
 {
@@ -13,10 +13,9 @@ namespace DashboardFrontend.ViewModels
         {
             Id = exec.Id;
             StartTime = exec.StartTime;
-            lock (executionLock)
-            {
-                Managers = new(exec.Managers.Select(m => new ManagerObservable(m)));
-            }
+
+            Managers = new(exec.Managers.Select(m => new ManagerObservable(m)));
+
             LogMessages = new(exec.Log.Messages);
         }
         public ExecutionObservable(Execution exec, ValidationReportViewModel vm) : this(exec)
@@ -36,7 +35,6 @@ namespace DashboardFrontend.ViewModels
 
         public DateTime? StartTime { get; set; }
         private int _failedTotalCount;
-        private readonly object executionLock = new();
         public int FailedTotalCount
         {
             get => _failedTotalCount; set

--- a/DashboardFrontend/ViewModels/ExecutionObservable.cs
+++ b/DashboardFrontend/ViewModels/ExecutionObservable.cs
@@ -13,7 +13,10 @@ namespace DashboardFrontend.ViewModels
         {
             Id = exec.Id;
             StartTime = exec.StartTime;
-            Managers = new(exec.Managers.Select(m => new ManagerObservable(m)));
+            lock(Managers)
+            {
+                Managers = new(exec.Managers.Select(m => new ManagerObservable(m)));
+            }
             LogMessages = new(exec.Log.Messages);
         }
         public ExecutionObservable(Execution exec, ValidationReportViewModel vm) : this(exec)

--- a/DashboardFrontend/ViewModels/LogViewModel.cs
+++ b/DashboardFrontend/ViewModels/LogViewModel.cs
@@ -173,7 +173,11 @@ namespace DashboardFrontend.ViewModels
 
         public void UpdateData(List<Execution> executions)
         {
-            Executions = new(executions.Select(e => new ExecutionObservable(e)));
+            Executions = new();
+            for(int i = 0; i < executions.Count; i++)
+            {
+                Executions.Add(new ExecutionObservable(executions[i]));
+            }
 
             if (SelectedExecution is null)
             {

--- a/DashboardFrontend/ViewModels/LogViewModel.cs
+++ b/DashboardFrontend/ViewModels/LogViewModel.cs
@@ -170,14 +170,10 @@ namespace DashboardFrontend.ViewModels
                 ScrollToLast();
             }
         }
-        private readonly object LocalLock = new();
 
         public void UpdateData(List<Execution> executions)
         {
-            lock(LocalLock)
-            {
-                Executions = new(executions.Select(e => new ExecutionObservable(e)));
-            }
+            Executions = new(executions.Select(e => new ExecutionObservable(e)));
 
             if (SelectedExecution is null)
             {

--- a/DashboardFrontend/ViewModels/LogViewModel.cs
+++ b/DashboardFrontend/ViewModels/LogViewModel.cs
@@ -173,7 +173,10 @@ namespace DashboardFrontend.ViewModels
 
         public void UpdateData(List<Execution> executions)
         {
-            Executions = new(executions.Select(e => new ExecutionObservable(e)));
+            lock(Executions)
+            {
+                Executions = new(executions.Select(e => new ExecutionObservable(e)));
+            }
             if (SelectedExecution is null)
             {
                 SelectedExecution = Executions.Last();

--- a/DashboardFrontend/ViewModels/LogViewModel.cs
+++ b/DashboardFrontend/ViewModels/LogViewModel.cs
@@ -170,13 +170,15 @@ namespace DashboardFrontend.ViewModels
                 ScrollToLast();
             }
         }
+        private readonly object LocalLock = new();
 
         public void UpdateData(List<Execution> executions)
         {
-            lock(Executions)
+            lock(LocalLock)
             {
                 Executions = new(executions.Select(e => new ExecutionObservable(e)));
             }
+
             if (SelectedExecution is null)
             {
                 SelectedExecution = Executions.Last();

--- a/DashboardFrontend/ViewModels/MainWindowViewModel.cs
+++ b/DashboardFrontend/ViewModels/MainWindowViewModel.cs
@@ -5,9 +5,10 @@ namespace DashboardFrontend.ViewModels
 {
     public class MainWindowViewModel : BaseViewModel
     {
-        public MainWindowViewModel(ListView listViewLog)
+        public MainWindowViewModel(ListView listViewLog, Window window)
         {
             Controller = new(this);
+            Window = window;
             Controller.InitializeViewModels(listViewLog);
         }
 
@@ -52,6 +53,8 @@ namespace DashboardFrontend.ViewModels
                 OnPropertyChanged(nameof(LoadingVisibility));
             }
         }
+
+        public Window Window { get; set; }
         public LogViewModel LogViewModel { get; set; }
         public ValidationReportViewModel ValidationReportViewModel { get; set; }
         public HealthReportViewModel HealthReportViewModel { get; set; }

--- a/DashboardFrontend/ViewModels/MainWindowViewModel.cs
+++ b/DashboardFrontend/ViewModels/MainWindowViewModel.cs
@@ -8,7 +8,6 @@ namespace DashboardFrontend.ViewModels
         public MainWindowViewModel(ListView listViewLog, Window window)
         {
             Controller = new(this);
-            Window = window;
             Controller.InitializeViewModels(listViewLog);
         }
 
@@ -53,8 +52,6 @@ namespace DashboardFrontend.ViewModels
                 OnPropertyChanged(nameof(LoadingVisibility));
             }
         }
-
-        public Window Window { get; set; }
         public LogViewModel LogViewModel { get; set; }
         public ValidationReportViewModel ValidationReportViewModel { get; set; }
         public HealthReportViewModel HealthReportViewModel { get; set; }

--- a/DashboardFrontend/ViewModels/ManagerChartViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerChartViewModel.cs
@@ -10,13 +10,14 @@ using Model;
 
 namespace DashboardFrontend.ViewModels
 {
-    public class ManagerChartViewModel
+    public class ManagerChartViewModel : BaseViewModel
     {
 
         #region Chart objects
         public DataChart CPUChart { get; private set; } = new(new ManagerChart("load"), false);
         public DataChart RAMChart { get; private set; } = new(new ManagerChart("load"), false);
         public List<DataChart> Charts { get; private set; } = new();
+        public List<double> FurthestPoints { get; private set; } = new();
         #endregion
 
         public ManagerChartViewModel()
@@ -31,32 +32,31 @@ namespace DashboardFrontend.ViewModels
         /// The manager to be added to the chart <param name="wrapper"></param>
         public void AddChartLinesHelper(ManagerWrapper wrapper)
         {
-            if (wrapper.Manager.CpuReadings.FirstOrDefault()?.Date is DateTime firstCpu)
-            {
-                wrapper.ManagerValues[0] = new(wrapper.Manager.CpuReadings.Select(p => CreatePoint(p, firstCpu)));
-            }
-            if (wrapper.Manager.RamReadings.FirstOrDefault()?.Date is DateTime firstRam)
-            {
-                wrapper.ManagerValues[1] = new(wrapper.Manager.RamReadings.Select(p => CreatePoint(p, firstRam)));
-            }
+            if (wrapper.Manager.CpuReadings.Count < 2) return;
+            DateTime firstCpu = wrapper.Manager.CpuReadings.First().Date;
+            wrapper.ManagerValues[0] = new(wrapper.Manager.CpuReadings.Select(p => CreatePoint(p, firstCpu)));
+            FurthestPoints.Add(wrapper.Manager.CpuReadings.Last().Date.ToOADate() - firstCpu.ToOADate());
+            DateTime firstRam = wrapper.Manager.RamReadings.First().Date;
+            wrapper.ManagerValues[1] = new(wrapper.Manager.RamReadings.Select(p => CreatePoint(p, firstRam)));
 
             int index = 0;
             foreach (DataChart chart in Charts)
             {
                 chart.AddLine(new LineSeries<ObservablePoint>
                 {
-                    Name = $"{wrapper.Manager.Name.Split(".").Last()}",
+                    Name = $"{wrapper.Manager.ShortName}",
                     Fill = null,
                     Stroke = new SolidColorPaint(SKColor.Parse(wrapper.LineColor.Color.ToString()), 3),
                     GeometryFill = new SolidColorPaint(SKColor.Parse(wrapper.LineColor.Color.ToString())),
                     GeometryStroke = new SolidColorPaint(SKColor.Parse(wrapper.LineColor.Color.ToString())),
                     GeometrySize = 0.4,
-                    TooltipLabelFormatter = e => $"({DateTime.FromOADate(e.SecondaryValue):HH:mm:ss}) {wrapper.Manager.Name.Split(".").Last()} [{wrapper.Manager.ContextId}]: {e.PrimaryValue:P}",
                     LineSmoothness = 0.5,
                     AnimationsSpeed = TimeSpan.FromMilliseconds(200),
                 }, wrapper.ManagerValues[index++]);
             }
+            UpdateView();
         }
+        /*e => $"({DateTime.FromOADate(e.SecondaryValue):HH:mm:ss}) {wrapper.Manager.ShortName} [{wrapper.Manager.ContextId}]: {e.PrimaryValue:P}"*/
 
         private ObservablePoint CreatePoint(PerformanceMetric pointData, DateTime first)
         {
@@ -70,10 +70,15 @@ namespace DashboardFrontend.ViewModels
         /// The manager to be removed <param name="manager"></param>
         public void RemoveChartLinesHelper(ManagerWrapper manager)
         {
+            if (manager.Manager.CpuReadings.Count < 2) return;
             for (int i = 0; i < Charts.Count; i++)
             {
                 Charts[i].RemoveData(manager.Manager.Name, manager.ManagerValues[i]);
             }
+            DateTime first = manager.Manager.CpuReadings.First().Date;
+            double offsetDate = manager.Manager.CpuReadings.Last().Date.ToOADate() - first.ToOADate();
+            FurthestPoints.Remove(offsetDate);
+            UpdateView();
         }
 
         /// <summary>
@@ -85,6 +90,18 @@ namespace DashboardFrontend.ViewModels
             {
                 chart.ChartData.Series.Clear();
             }
+            UpdateView();
+        }
+
+        private void UpdateView()
+        {
+            double MaxLimit = 0;
+            if (FurthestPoints.Any())
+            {
+                MaxLimit = FurthestPoints.Max();
+            }
+            CPUChart.ChartData.XAxis[0].MaxLimit = MaxLimit;
+            RAMChart.ChartData.XAxis[0].MaxLimit = MaxLimit;
         }
     }
 }

--- a/DashboardFrontend/ViewModels/ManagerChartViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerChartViewModel.cs
@@ -90,6 +90,7 @@ namespace DashboardFrontend.ViewModels
             {
                 chart.ChartData.Series.Clear();
             }
+            FurthestPoints = new();
             UpdateView();
         }
 

--- a/DashboardFrontend/ViewModels/ManagerObservable.cs
+++ b/DashboardFrontend/ViewModels/ManagerObservable.cs
@@ -16,8 +16,10 @@ namespace DashboardFrontend.ViewModels
             Score = mgr.Score;
             Validations = new(mgr.Validations);
             ValidationView = (CollectionView)CollectionViewSource.GetDefaultView(Validations);
+            OriginalManager = mgr;
         }
 
+        public Manager OriginalManager { get; private set; }
         public List<ValidationTest> Validations = new();
         private CollectionView _validationView;
         public CollectionView ValidationView

--- a/DashboardFrontend/ViewModels/ManagerViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerViewModel.cs
@@ -14,14 +14,17 @@ namespace DashboardFrontend.ViewModels
             ManagerChartViewModel = new();
         }
 
-        public ManagerViewModel(DataGrid dataGrid)
-        {
-            _datagrid = dataGrid;
-        }
-
         public DateTime LastUpdated { get; set; } = DateTime.MinValue;
-        private readonly DataGrid _datagrid;
+        private string _managerSearch = string.Empty;
+        public string ManagerSearch { get => _managerSearch; 
+            set
+            {
+                _managerSearch = value;
+                SearchManagers();
+            }
+        }
         private ObservableCollection<ManagerWrapper> _managers = new();
+        public DataGrid DatagridManagers;
         public ManagerChartViewModel ManagerChartViewModel { get; set; }
         public ObservableCollection<ManagerWrapper> Managers
         {
@@ -42,34 +45,7 @@ namespace DashboardFrontend.ViewModels
                 OnPropertyChanged(nameof(WrappedManagers));
             }
         }
-
-        private string _managerSearch = string.Empty;
-        public string ManagerSearch
-        {
-            get => _managerSearch;
-            set
-            {
-                _managerSearch = value;
-                OnPropertyChanged(nameof(ManagerSearch));
-                SearchManagers();
-            }
-        }
-
-        public void SearchManagers()
-        {
-            foreach (ManagerWrapper manager in Managers)
-            {
-                DataGridRow row = (DataGridRow)_datagrid.ItemContainerGenerator.ContainerFromItem(manager);
-                if (!manager.Manager.Name.Contains(ManagerSearch))
-                {
-                    row.Visibility = Visibility.Collapsed;
-                }
-                else
-                {
-                    row.Visibility = Visibility.Visible;
-                }
-            }
-        }
+        public List<string> ExpandedManagerNames = new();
 
         public void UpdateData(List<Manager> executionManagers)
         {
@@ -77,6 +53,27 @@ namespace DashboardFrontend.ViewModels
             foreach (var manager in executionManagers)
             {
                 Managers.Add(new ManagerWrapper(manager));
+            }
+        }
+
+        private void SearchManagers()
+        {
+            DatagridManagers.SelectedItems.Clear();
+            if (!string.IsNullOrEmpty(ManagerSearch))
+            {
+                List<ManagerWrapper> foundManagers = new();
+                foreach (ManagerWrapper manager in DatagridManagers.Items)
+                {
+                    if (manager.Manager.Name.ToLower().Contains(ManagerSearch.ToLower()) || manager.Manager.ContextId.ToString() == ManagerSearch)
+                    {
+                        foundManagers.Add(manager);
+                        DatagridManagers.SelectedItems.Add(manager);
+                    }
+                }
+            }
+            else
+            {
+                DatagridManagers.SelectedItems.Clear();
             }
         }
     }

--- a/DashboardFrontend/ViewModels/ManagerViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerViewModel.cs
@@ -14,6 +14,11 @@ namespace DashboardFrontend.ViewModels
             ManagerChartViewModel = new();
         }
 
+        public ManagerViewModel(Window detachedWindow) : this()
+        {
+            Window = detachedWindow;
+        }
+
         public DateTime LastUpdated { get; set; } = DateTime.MinValue;
         private string _managerSearch = string.Empty;
         public string ManagerSearch { get => _managerSearch; 
@@ -33,6 +38,7 @@ namespace DashboardFrontend.ViewModels
             }
         }
         public ManagerChartViewModel ManagerChartViewModel { get; set; }
+        public Window Window { get; set; }
         public ObservableCollection<ManagerWrapper> Managers
         {
             get => _managers;

--- a/DashboardFrontend/ViewModels/ManagerViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerViewModel.cs
@@ -22,6 +22,7 @@ namespace DashboardFrontend.ViewModels
             get => _selectedExecution;
             set
             {
+                ManagerChartViewModel.ClearChartLinesHelper();
                 _selectedExecution = value;
                 OnPropertyChanged(nameof(SelectedExecution));
                 SetExecution(value);

--- a/DashboardFrontend/ViewModels/ManagerViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerViewModel.cs
@@ -14,6 +14,18 @@ namespace DashboardFrontend.ViewModels
             ManagerChartViewModel = new();
         }
 
+        public ObservableCollection<ExecutionObservable> Executions { get; set; } = new();
+        private ExecutionObservable? _selectedExecution;
+        public ExecutionObservable? SelectedExecution
+        {
+            get => _selectedExecution;
+            set
+            {
+                _selectedExecution = value;
+                OnPropertyChanged(nameof(SelectedExecution));
+                SetExecution(value);
+            }
+        }
         public DateTime LastUpdated { get; set; } = DateTime.MinValue;
         private string _managerSearch = string.Empty;
         public string ManagerSearch { get => _managerSearch; 
@@ -47,12 +59,29 @@ namespace DashboardFrontend.ViewModels
         }
         public List<string> ExpandedManagerNames = new();
 
-        public void UpdateData(List<Manager> executionManagers)
+        public void UpdateData(List<Execution> executions)
         {
-            Managers.Clear();
-            foreach (var manager in executionManagers)
+            Executions.Clear();
+            int count = executions.Count;
+            for (int i = 0; i < count; i++)
             {
-                Managers.Add(new ManagerWrapper(manager));
+                Executions.Add(new ExecutionObservable(executions[i]));
+            }
+            if (SelectedExecution is null && count > 0)
+            {
+                SelectedExecution = Executions[^1];
+            }
+        }
+
+        private void SetExecution(ExecutionObservable exec)
+        {
+            if (exec is not null)
+            {
+                Managers.Clear();
+                foreach (var manager in exec.Managers)
+                {
+                    Managers.Add(new ManagerWrapper(manager.OriginalManager));
+                }
             }
         }
 

--- a/DashboardFrontend/ViewModels/ManagerViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerViewModel.cs
@@ -20,11 +20,18 @@ namespace DashboardFrontend.ViewModels
             set
             {
                 _managerSearch = value;
-                SearchManagers();
+                if (DataGridManagers != null) _dataGridManagers.Items.Filter = OnManagersFilter;
             }
         }
         private ObservableCollection<ManagerWrapper> _managers = new();
-        public DataGrid DatagridManagers;
+        private DataGrid _dataGridManagers;
+        public DataGrid DataGridManagers { 
+            get => _dataGridManagers; 
+            set
+            {
+                _dataGridManagers = value;
+            }
+        }
         public ManagerChartViewModel ManagerChartViewModel { get; set; }
         public ObservableCollection<ManagerWrapper> Managers
         {
@@ -54,27 +61,13 @@ namespace DashboardFrontend.ViewModels
             {
                 Managers.Add(new ManagerWrapper(manager));
             }
+            if (DataGridManagers != null) DataGridManagers.Items.Filter = OnManagersFilter;
         }
 
-        private void SearchManagers()
+        private bool OnManagersFilter(object item)
         {
-            DatagridManagers.SelectedItems.Clear();
-            if (!string.IsNullOrEmpty(ManagerSearch))
-            {
-                List<ManagerWrapper> foundManagers = new();
-                foreach (ManagerWrapper manager in DatagridManagers.Items)
-                {
-                    if (manager.Manager.Name.ToLower().Contains(ManagerSearch.ToLower()) || manager.Manager.ContextId.ToString() == ManagerSearch)
-                    {
-                        foundManagers.Add(manager);
-                        DatagridManagers.SelectedItems.Add(manager);
-                    }
-                }
-            }
-            else
-            {
-                DatagridManagers.SelectedItems.Clear();
-            }
+            ManagerWrapper mgr = (ManagerWrapper)item;
+            return (mgr.Manager.Name.ToLower().Contains(ManagerSearch.ToLower()) || mgr.Manager.ContextId.ToString() == ManagerSearch);
         }
     }
 }

--- a/DashboardFrontend/ViewModels/ManagerViewModel.cs
+++ b/DashboardFrontend/ViewModels/ManagerViewModel.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -29,16 +30,6 @@ namespace DashboardFrontend.ViewModels
             }
         }
         private ObservableCollection<ManagerWrapper> _managers = new();
-        private DataGrid _dataGridManagers;
-        public DataGrid DataGridManagers { 
-            get => _dataGridManagers; 
-            set
-            {
-                _dataGridManagers = value;
-            }
-        }
-        public ManagerChartViewModel ManagerChartViewModel { get; set; }
-        public Window Window { get; set; }
         public ObservableCollection<ManagerWrapper> Managers
         {
             get => _managers;
@@ -48,18 +39,35 @@ namespace DashboardFrontend.ViewModels
                 OnPropertyChanged(nameof(Managers));
             }
         }
-        private ObservableCollection<ManagerWrapper> _wrappedManagers = new();
-        public ObservableCollection<ManagerWrapper> WrappedManagers
+
+        private ObservableCollection<ManagerWrapper> _detailedManagers = new();
+        public ObservableCollection<ManagerWrapper> DetailedManagers
         {
-            get => _wrappedManagers;
+            get => _detailedManagers;
             set
             {
-                _wrappedManagers = value;
-                OnPropertyChanged(nameof(WrappedManagers));
+                _detailedManagers = value;
+                OnPropertyChanged(nameof(DetailedManagers));
             }
         }
-        public List<string> ExpandedManagerNames = new();
+        private DataGrid _dataGridManagers;
+        public DataGrid DataGridManagers { 
+            get => _dataGridManagers; 
+            set
+            {
+                _dataGridManagers = value;
+            }
+        }
+        public int HiddenManagers { get; set; }
 
+        public void UpdateHiddenManagers()
+        {
+            HiddenManagers = DetailedManagers.Where(m => m.Manager.CpuReadings.Count < 2).Count();
+            OnPropertyChanged(nameof(HiddenManagers));
+        }
+        public ManagerChartViewModel ManagerChartViewModel { get; set; }
+        public Window Window { get; set; }
+        
         public void UpdateData(List<Manager> executionManagers)
         {
             Managers.Clear();

--- a/DashboardFrontend/ViewModels/ManagerWrapper.cs
+++ b/DashboardFrontend/ViewModels/ManagerWrapper.cs
@@ -26,6 +26,16 @@ namespace DashboardFrontend
                 OnPropertyChanged(nameof(IsDetailedInfoShown));
             }
         }
+        private bool _isVisible = true;
+        public bool IsVisible
+        {
+            get => _isVisible;
+            set
+            {
+                _isVisible = value;
+                OnPropertyChanged(nameof(IsVisible));
+            }
+        }
 
         public ManagerWrapper(Manager manager)
         {

--- a/Model/Manager.cs
+++ b/Model/Manager.cs
@@ -34,15 +34,7 @@ namespace Model
             set
             {
                 _name = value;
-                var splitName = value.Split('.');
-                if (splitName.Contains("managers"))
-                {
-                    ShortName = "(...)" + string.Join(".", splitName.TakeLast(2));
-                }
-                else
-                {
-                    ShortName = "(...)" + string.Join(".", splitName.Skip(4));
-                }
+                ShortName = value.Split(".").Last();
             }
         } //[MANAGER_NAME] from [dbo].[MANAGERS]
         public int ContextId { get; set; }


### PR DESCRIPTION
Lots of changes - notable ones include, but are not limited to:

* Redesigned detached manager window - now shows more info in detailed view, switches sides  when 'expanded'.

* Search is now fuzzy search.

* Can move managers with double click or enter, added tooltips to describe actions on managers in datagrids, or their name in the case of the chart.

* Improved manager charts vastly, now only plots if they have 'enough' data, view is fitted to series, can zoom.

* Changed cursor for all plots, added wait cursor when main window loading. 

* Manager can now be inspected in detached window by double clicking in main window manager view